### PR TITLE
chore: update execute strategy so status returns human readable string

### DIFF
--- a/typescript/src/shared/strategies/tx-mode-strategy.ts
+++ b/typescript/src/shared/strategies/tx-mode-strategy.ts
@@ -11,7 +11,7 @@ interface TxModeStrategy {
 }
 
 export interface RawTransactionResponse {
-  status: number;
+  status: string;
   accountId: AccountId | null;
   tokenId: TokenId | null;
   transactionId: string;
@@ -37,7 +37,7 @@ class ExecuteStrategy implements TxModeStrategy {
     const submit = await tx.execute(client);
     const receipt = await submit.getReceipt(client);
     const rawTransactionResponse: RawTransactionResponse = {
-      status: receipt.status._code,
+      status: receipt.status.toString(),
       accountId: receipt.accountId,
       tokenId: receipt.tokenId,
       transactionId: tx.transactionId?.toString() ?? '',


### PR DESCRIPTION
**Description**:
This PR modifies the execute transaction strategy so that it returns a human readable string for the status rather than the number. This reduces risk of autonomous agents hallucinating when seeing Hedera specific status codes like 22 and thinking the transaction is not successful.

**Related issue(s)**:

Fixes #179 

**Checklist**

- [ ] Documented (Code comments, README, etc.) - N/A; The change is purely internal to the transaction strategy implementation and doesn't affect the public API or user-facing documentation that would need updates.
- [x] Tested (unit, integration, etc.)
