### PR TITLE
feat: add Delete Account tool to core-account-plugin

### DIFF
--- a/docs/HEDERAPLUGINS.md
+++ b/docs/HEDERAPLUGINS.md
@@ -23,14 +23,15 @@ Plugins can be found in [typescript/src/plugins](../typescript/src/plugins)
 ### Core Account Plugin Tools (core-account-plugin)
 This plugin provides tools for Hedera Account Service operations
 
-| Tool Name                                       | Description                                        |Usage                                             |
-| ----------------------------------------------- | -------------------------------------------------- |--------------------------------------------------------- |
-| `TRANSFER_HBAR_TOOL`| Transfer HBAR between accounts | Provide the amount of of HBAR to transfer, the account to transfer to, and optionally, a transaction memo.|
+| Tool Name                                       | Description                                        | Usage                                                                                                                                                                                              |
+| ----------------------------------------------- | -------------------------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `TRANSFER_HBAR_TOOL`| Transfer HBAR between accounts | Provide the amount of of HBAR to transfer, the account to transfer to, and optionally, a transaction memo.                                                                                         |
+| `DELETE_ACCOUNT_TOOL`| Delete an account and send all remaining assets to a specified account | Provide the ID of account to delete (required) and the transfer account ID to send the remaining assets to (optional). If transfer account is not specified the operator's account ID will be used |
 
 ### Core Hedera Consensus Service Plugin Tools (core-consensus-plugin)
 
 | Tool Name                                       | Description                                        |  Usage                                             |
-| ----------------------------------------------- | -------------------------------------------------- | --------------------------------------------------------- |
+| ----------------------------------------------- | -------------------------------------------------- | ------------------------account ID --------------------------------- |
 | `CREATE_TOPIC_TOOL`| Create a new topic on the Hedera network | Optionally provide a topic memo (string) and whether to set a submit key (boolean - set to true if you want to set a submit key, otherwise false)| 
 | `SUBMIT_TOPIC_MESSAGE_TOOL`| Submit a message to a topic on the Hedera network | Provide the topic ID (string, required) and the message to submit (string, required)| 
 

--- a/typescript/examples/langchain/package-lock.json
+++ b/typescript/examples/langchain/package-lock.json
@@ -27,6 +27,7 @@
       "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@elizaos/core": "1.4.2",
         "@hashgraph/sdk": "^2.68.0",
         "@langchain/core": "^0.3.66",
         "@modelcontextprotocol/sdk": "^1.16.0",

--- a/typescript/examples/langchain/plugin-tool-calling-agent.ts
+++ b/typescript/examples/langchain/plugin-tool-calling-agent.ts
@@ -1,4 +1,15 @@
-import { HederaLangchainToolkit, AgentMode, coreHTSPluginToolNames, coreConsensusPluginToolNames, coreQueriesPluginToolNames, coreQueriesPlugin, coreHTSPlugin, coreConsensusPlugin } from 'hedera-agent-kit';
+import {
+  HederaLangchainToolkit,
+  AgentMode,
+  coreHTSPluginToolNames,
+  coreConsensusPluginToolNames,
+  coreQueriesPluginToolNames,
+  coreQueriesPlugin,
+  coreHTSPlugin,
+  coreConsensusPlugin,
+  coreAccountPlugin,
+  coreAccountPluginToolNames,
+} from 'hedera-agent-kit';
 import { ChatOpenAI } from '@langchain/openai';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
 import { AgentExecutor, createToolCallingAgent } from 'langchain/agents';
@@ -22,19 +33,13 @@ async function bootstrap(): Promise<void> {
   );
 
   // all the available tools
-  const {
-    CREATE_FUNGIBLE_TOKEN_TOOL,
-  } = coreHTSPluginToolNames;
+  const { CREATE_FUNGIBLE_TOKEN_TOOL } = coreHTSPluginToolNames;
 
-  const {
-    CREATE_TOPIC_TOOL,
-    SUBMIT_TOPIC_MESSAGE_TOOL,
-  } = coreConsensusPluginToolNames;
+  const { CREATE_TOPIC_TOOL, SUBMIT_TOPIC_MESSAGE_TOOL } = coreConsensusPluginToolNames;
 
-  const {
-    GET_HBAR_BALANCE_QUERY_TOOL,
-  } = coreQueriesPluginToolNames;
+  const { GET_HBAR_BALANCE_QUERY_TOOL } = coreQueriesPluginToolNames;
 
+  const { DELETE_ACCOUNT_TOOL, TRANSFER_HBAR_TOOL } = coreAccountPluginToolNames;
 
   // Prepare Hedera toolkit with core tools AND custom plugin
   const hederaAgentToolkit = new HederaLangchainToolkit({
@@ -46,11 +51,19 @@ async function bootstrap(): Promise<void> {
         SUBMIT_TOPIC_MESSAGE_TOOL,
         CREATE_FUNGIBLE_TOKEN_TOOL,
         GET_HBAR_BALANCE_QUERY_TOOL,
+        DELETE_ACCOUNT_TOOL,
+        TRANSFER_HBAR_TOOL,
         // Plugin tools
         'example_greeting_tool',
         'example_hbar_transfer_tool',
       ],
-      plugins: [examplePlugin, coreHTSPlugin, coreConsensusPlugin, coreQueriesPlugin], // Add the example plugin
+      plugins: [
+        examplePlugin,
+        coreHTSPlugin,
+        coreConsensusPlugin,
+        coreQueriesPlugin,
+        coreAccountPlugin,
+      ], // Add the example plugin
       context: {
         mode: AgentMode.AUTONOMOUS,
       },
@@ -59,7 +72,10 @@ async function bootstrap(): Promise<void> {
 
   // Load the structured chat prompt template
   const prompt = ChatPromptTemplate.fromMessages([
-    ['system', 'You are a helpful assistant with access to Hedera blockchain tools and custom plugin tools'],
+    [
+      'system',
+      'You are a helpful assistant with access to Hedera blockchain tools and custom plugin tools',
+    ],
     ['placeholder', '{chat_history}'],
     ['human', '{input}'],
     ['placeholder', '{agent_scratchpad}'],
@@ -94,7 +110,9 @@ async function bootstrap(): Promise<void> {
   console.log('Hedera Agent CLI Chatbot with Plugin Support — type "exit" to quit');
   console.log('Available plugin tools:');
   console.log('- example_greeting_tool: Generate personalized greetings');
-  console.log('- example_hbar_transfer_tool: Transfer HBAR to account 0.0.800 (demonstrates transaction strategy)');
+  console.log(
+    '- example_hbar_transfer_tool: Transfer HBAR to account 0.0.800 (demonstrates transaction strategy)',
+  );
   console.log('');
 
   while (true) {
@@ -119,9 +137,11 @@ async function bootstrap(): Promise<void> {
   }
 }
 
-bootstrap().catch(err => {
-  console.error('Fatal error during CLI bootstrap:', err);
-  process.exit(1);
-}).then(() => {
-  process.exit(0);
-});
+bootstrap()
+  .catch(err => {
+    console.error('Fatal error during CLI bootstrap:', err);
+    process.exit(1);
+  })
+  .then(() => {
+    process.exit(0);
+  });

--- a/typescript/src/plugins/core-account-plugin/index.ts
+++ b/typescript/src/plugins/core-account-plugin/index.ts
@@ -3,18 +3,22 @@ import { Plugin } from '@/shared/plugin';
 import transferHbarTool, {
   TRANSFER_HBAR_TOOL,
 } from '@/plugins/core-account-plugin/tools/account/transfer-hbar';
+import deleteAccountTool, {
+  DELETE_ACCOUNT_TOOL,
+} from '@/plugins/core-account-plugin/tools/account/delete-account';
 
 export const coreAccountPlugin: Plugin = {
   name: 'core-account-plugin',
   version: '1.0.0',
   description: 'A plugin for the Hedera Account Service',
   tools: (context: Context) => {
-    return [transferHbarTool(context)];
+    return [transferHbarTool(context), deleteAccountTool(context)];
   },
 };
 
 export const coreAccountPluginToolNames = {
   TRANSFER_HBAR_TOOL,
+  DELETE_ACCOUNT_TOOL,
 } as const;
 
 export default { coreAccountPlugin, coreAccountPluginToolNames };

--- a/typescript/src/plugins/core-account-plugin/tools/account/delete-account.ts
+++ b/typescript/src/plugins/core-account-plugin/tools/account/delete-account.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import type { Context } from '@/shared/configuration';
+import type { Tool } from '@/shared/tools';
+import { Client } from '@hashgraph/sdk';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
+import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
+import { PromptGenerator } from '@/shared/utils/prompt-generator';
+import { deleteAccountParameters } from '@/shared/parameter-schemas/has.zod';
+import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
+
+const deleteAccountPrompt = (context: Context = {}) => {
+  const contextSnippet = PromptGenerator.getContextSnippet(context);
+  const accountDesc = PromptGenerator.getAccountParameterDescription('accountId', context);
+  const usageInstructions = PromptGenerator.getParameterUsageInstructions();
+
+  return `
+${contextSnippet}
+
+This tool will delete an existing Hedera account. The remaining balance of the account will be transferred to the transferAccountId if provided, otherwise the operator account will be used.
+
+Parameters:
+- ${accountDesc}
+- accountId (str, required): The account ID to delete
+- transferAccountId (str, optional): The account ID to transfer the remaining balance to. If not provided, the operator account will be used.
+${usageInstructions}
+`;
+};
+
+const postProcess = (response: RawTransactionResponse) => {
+  return `Account successfully deleted. Transaction ID: ${response.transactionId}`;
+};
+
+const deleteAccount = async (
+  client: Client,
+  context: Context,
+  params: z.infer<ReturnType<typeof deleteAccountParameters>>,
+) => {
+  try {
+    const normalisedParams = HederaParameterNormaliser.normaliseDeleteAccount(
+      params,
+      context,
+      client,
+    );
+
+    let tx = HederaBuilder.deleteAccount(normalisedParams);
+
+    const result = await handleTransaction(tx, client, context, postProcess);
+    return result;
+  } catch (error) {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return 'Failed to delete account';
+  }
+};
+
+export const DELETE_ACCOUNT_TOOL = 'delete_account_tool';
+
+const tool = (context: Context): Tool => ({
+  method: DELETE_ACCOUNT_TOOL,
+  name: 'Delete Account',
+  description: deleteAccountPrompt(context),
+  parameters: deleteAccountParameters(context),
+  execute: deleteAccount,
+});
+
+export default tool;

--- a/typescript/src/shared/hedera-utils/hedera-builder.ts
+++ b/typescript/src/shared/hedera-utils/hedera-builder.ts
@@ -6,6 +6,7 @@ import {
   TransferTransaction,
   ContractExecuteTransaction,
   TokenMintTransaction,
+  AccountDeleteTransaction,
 } from '@hashgraph/sdk';
 import {
   airdropFungibleTokenParametersNormalised,
@@ -15,7 +16,10 @@ import {
   mintNonFungibleTokenParametersNormalised,
 } from '@/shared/parameter-schemas/hts.zod';
 import z from 'zod';
-import { transferHbarParametersNormalised } from '@/shared/parameter-schemas/has.zod';
+import {
+  deleteAccountParametersNormalised,
+  transferHbarParametersNormalised,
+} from '@/shared/parameter-schemas/has.zod';
 import {
   createTopicParametersNormalised,
   submitTopicMessageParametersNormalised,
@@ -71,5 +75,9 @@ export default class HederaBuilder {
     params: z.infer<ReturnType<typeof mintNonFungibleTokenParametersNormalised>>,
   ) {
     return new TokenMintTransaction(params);
+  }
+
+  static deleteAccount(params: z.infer<ReturnType<typeof deleteAccountParametersNormalised>>) {
+    return new AccountDeleteTransaction(params);
   }
 }

--- a/typescript/src/shared/parameter-schemas/has.zod.ts
+++ b/typescript/src/shared/parameter-schemas/has.zod.ts
@@ -34,3 +34,15 @@ export const transferHbarParametersNormalised = (_context: Context = {}) =>
     ),
     transactionMemo: z.string().optional(),
   });
+
+export const deleteAccountParameters = (_context: Context = {}) =>
+  z.object({
+    accountId: z.string().describe('The account ID to delete.'),
+    transferAccountId: z.string().optional().describe('The ID of the account to transfer the remaining funds to. If not provided, the operator account ID will be used.'),
+  });
+
+export const deleteAccountParametersNormalised = (_context: Context = {}) =>
+  z.object({
+    accountId: z.instanceof(AccountId),
+    transferAccountId: z.instanceof(AccountId),
+  })


### PR DESCRIPTION
**Description**:
Introduces a new `DELETE_ACCOUNT_TOOL` to the `core-account-plugin`, enabling the deletion of accounts on the Hedera network with optional fund transfer settings. Includes tool implementation, parameter schemas, and usage updates.
**Related issue(s)**:
 #150 

**Notes for reviewer**:
testes with `examples/langchain`

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
