### PR TITLE
feat: add optional fromAddress parameter to ERC721 transfer tool

### DIFF
--- a/typescript/src/plugins/core-evm-plugin/tools/erc721/transfer-erc721.ts
+++ b/typescript/src/plugins/core-evm-plugin/tools/erc721/transfer-erc721.ts
@@ -15,6 +15,7 @@ import { transferERC721Parameters } from '@/shared/parameter-schemas/evm.zod';
 
 const transferERC721Prompt = (context: Context = {}) => {
   const contextSnippet = PromptGenerator.getContextSnippet(context);
+  const fromAddressDesc = PromptGenerator.getAnyAddressParameterDescription('fromAddress', context);
   const usageInstructions = PromptGenerator.getParameterUsageInstructions();
 
   return `
@@ -24,7 +25,7 @@ This tool will transfer an existing ERC721 token on Hedera.
 
 Parameters:
 - contractId (str, required): The id of the ERC721 contract
-- fromAddress (str, required): The address from which the token will be transfered. This can be the EVM address or the Hedera account id.
+- ${fromAddressDesc}
 - toAddress (str, required): The address to which the token will be transferred. This can be the EVM address or the Hedera account id.
 - tokenId (number, required): The ID of the transfered token
 ${usageInstructions}
@@ -48,6 +49,7 @@ const transferERC721 = async (
       ERC721_TRANSFER_FUNCTION_NAME,
       context,
       mirrorNode,
+      client,
     );
     const tx = HederaBuilder.executeTransaction(normalisedParams);
     const result = await handleTransaction(tx, client, context);

--- a/typescript/src/shared/hedera-utils/hedera-parameter-normaliser.ts
+++ b/typescript/src/shared/hedera-utils/hedera-parameter-normaliser.ts
@@ -370,7 +370,7 @@ export default class HederaParameterNormaliser {
     _context: Context,
     mirrorNode: IHederaMirrornodeService,
   ) {
-    const recipientAddress = await HederaParameterNormaliser.getHederaEVMAddress(
+    const recipientAddress = await AccountResolver.getHederaEVMAddress(
       params.recipientAddress,
       mirrorNode,
     );
@@ -403,11 +403,11 @@ export default class HederaParameterNormaliser {
   ) {
     // Resolve fromAddress using AccountResolver pattern, similar to transfer-hbar
     const resolvedFromAddress = AccountResolver.resolveAccount(params.fromAddress, context, client);
-    const fromAddress = await HederaParameterNormaliser.getHederaEVMAddress(
+    const fromAddress = await AccountResolver.getHederaEVMAddress(
       resolvedFromAddress,
       mirrorNode,
     );
-    const toAddress = await HederaParameterNormaliser.getHederaEVMAddress(
+    const toAddress = await AccountResolver.getHederaEVMAddress(
       params.toAddress,
       mirrorNode,
     );
@@ -438,7 +438,7 @@ export default class HederaParameterNormaliser {
     _context: Context,
     mirrorNode: IHederaMirrornodeService,
   ) {
-    const toAddress = await HederaParameterNormaliser.getHederaEVMAddress(
+    const toAddress = await AccountResolver.getHederaEVMAddress(
       params.toAddress,
       mirrorNode,
     );
@@ -535,17 +535,6 @@ export default class HederaParameterNormaliser {
     }
 
     return normalised;
-  }
-
-  static async getHederaEVMAddress(
-    address: string,
-    mirrorNode: IHederaMirrornodeService,
-  ): Promise<string> {
-    if (!AccountResolver.isHederaAddress(address)) {
-      return address;
-    }
-    const account = await mirrorNode.getAccount(address);
-    return account.evmAddress;
   }
 
   static async getHederaAccountId(

--- a/typescript/src/shared/hedera-utils/hedera-parameter-normaliser.ts
+++ b/typescript/src/shared/hedera-utils/hedera-parameter-normaliser.ts
@@ -397,11 +397,14 @@ export default class HederaParameterNormaliser {
     params: z.infer<ReturnType<typeof transferERC721Parameters>>,
     factoryContractAbi: string[],
     factoryContractFunctionName: string,
-    _context: Context,
+    context: Context,
     mirrorNode: IHederaMirrornodeService,
+    client: Client,
   ) {
+    // Resolve fromAddress using AccountResolver pattern, similar to transfer-hbar
+    const resolvedFromAddress = AccountResolver.resolveAccount(params.fromAddress, context, client);
     const fromAddress = await HederaParameterNormaliser.getHederaEVMAddress(
-      params.fromAddress,
+      resolvedFromAddress,
       mirrorNode,
     );
     const toAddress = await HederaParameterNormaliser.getHederaEVMAddress(

--- a/typescript/src/shared/parameter-schemas/evm.zod.ts
+++ b/typescript/src/shared/parameter-schemas/evm.zod.ts
@@ -40,7 +40,7 @@ export const createERC20Parameters = (_context: Context = {}) =>
 export const transferERC721Parameters = (_context: Context = {}) =>
   z.object({
     contractId: z.string().describe('The id of the ERC721 contract.'),
-    fromAddress: z.string().describe('Address from which the token will be transferred.'),
+    fromAddress: z.string().optional().describe('Address from which the token will be transferred.'),
     toAddress: z.string().describe('Address to which the token will be transferred.'),
     tokenId: z.number().describe('The ID of the token to transfer.'),
   });

--- a/typescript/src/shared/utils/prompt-generator.ts
+++ b/typescript/src/shared/utils/prompt-generator.ts
@@ -34,6 +34,18 @@ export class PromptGenerator {
     return lines.join('\n');
   }
 
+  static getAnyAddressParameterDescription(   
+    paramName: string,
+    context: Context,
+    isRequired: boolean = false,
+  ): string {
+    if (isRequired) {
+      return `${paramName} (str, required): The account address. This can be the EVM address or the Hedera account id`;
+    }
+
+    return `${paramName} (str, optional): The Hedera account ID or EVM address. If not provided, defaults to the ${AccountResolver.getDefaultAccountDescription(context)}`;
+  }
+
   /**
    * Generates a consistent description for optional account parameters.
    */


### PR DESCRIPTION


**Description**:
- Make fromAddress optional in transferERC721Parameters schema
- Use AccountResolver to default to context.accountId when fromAddress is omitted
- Update tool description to use PromptGenerator.getAnyAddressParameterDescription()
- Follow same pattern as transfer-hbar tool's sourceAccountId parameter
- Maintain backward compatibility with explicit fromAddress values


**Related issue(s)**:
Fixes #218

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
