### PR TITLE
fix: typing issues with typescript and zod schemas

### DIFF
--- a/typescript/src/shared/hedera-utils/hedera-parameter-normaliser.ts
+++ b/typescript/src/shared/hedera-utils/hedera-parameter-normaliser.ts
@@ -35,7 +35,6 @@ import { TokenTransferMinimalParams, TransferHbarInput } from '@/shared/hedera-u
 import { AccountResolver } from '@/shared/utils/account-resolver';
 import { ethers } from 'ethers';
 import {
-  contractExecuteTransactionParametersNormalised,
   createERC20Parameters,
   createERC721Parameters,
   mintERC721Parameters,
@@ -342,7 +341,7 @@ export default class HederaParameterNormaliser {
     factoryContractAbi: string[],
     factoryContractFunctionName: string,
     context: Context,
-  ): z.infer<ReturnType<typeof contractExecuteTransactionParametersNormalised>> {
+  ) {
     const parsedParams: z.infer<ReturnType<typeof createERC20Parameters>> =
       this.parseParamsWithSchema(params, createERC20Parameters, context);
 

--- a/typescript/test/integration/hedera/create-account.integration.test.ts
+++ b/typescript/test/integration/hedera/create-account.integration.test.ts
@@ -3,8 +3,6 @@ import { Client, Key, PrivateKey } from '@hashgraph/sdk';
 import createAccountTool from '@/plugins/core-account-plugin/tools/account/create-account';
 import { Context, AgentMode } from '@/shared/configuration';
 import { getCustomClient, getOperatorClientForTests, HederaOperationsWrapper } from '../../utils';
-import { z } from 'zod';
-import { createAccountParameters } from '@/shared/parameter-schemas/account.zod';
 
 describe('Create Account Integration Tests', () => {
   let operatorClient: Client;
@@ -53,7 +51,7 @@ describe('Create Account Integration Tests', () => {
 
   describe('Valid Create Account Scenarios', () => {
     it('should create an account with executor public key by default', async () => {
-      const params: z.infer<ReturnType<typeof createAccountParameters>> = {};
+      const params = {};
 
       const tool = createAccountTool(context);
       const result = await tool.execute(executorClient, context, params);
@@ -71,7 +69,7 @@ describe('Create Account Integration Tests', () => {
     });
 
     it('should create an account with initial balance and memo', async () => {
-      const params: z.infer<ReturnType<typeof createAccountParameters>> = {
+      const params = {
         initialBalance: 0.05,
         accountMemo: 'Integration test account',
       };
@@ -93,7 +91,7 @@ describe('Create Account Integration Tests', () => {
 
     it('should create an account with explicit public key', async () => {
       const publicKey = executorClient.operatorPublicKey as Key;
-      const params: z.infer<ReturnType<typeof createAccountParameters>> = {
+      const params = {
         publicKey: publicKey.toString(),
       };
 
@@ -107,7 +105,7 @@ describe('Create Account Integration Tests', () => {
 
   describe('Invalid Create Account Scenarios', () => {
     it('should fail with invalid public key', async () => {
-      const params: z.infer<ReturnType<typeof createAccountParameters>> = {
+      const params = {
         publicKey: 'not-a-valid-public-key',
       };
 
@@ -124,7 +122,7 @@ describe('Create Account Integration Tests', () => {
     });
 
     it('should fail with negative initial balance', async () => {
-      const params: z.infer<ReturnType<typeof createAccountParameters>> = {
+      const params = {
         initialBalance: -1,
       };
 


### PR DESCRIPTION
**Description**:
This PR fixes TS error that do not affect how the code works.
 Errors in `create-account.integration.test.ts` are caused by TS not knowing that some of the object properties are optional and have default values even tho the are defined like that in the zod schemas. 
 Errors in Hedera parameter normalizer are caused by narrowing the return type of function despite returning more data.

**Checklist**
- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
