### PR TITLE
test: add integration tests for tx memo in submit and topic creation

### DIFF
--- a/typescript/test/integration/hedera/submit-topic-message.integration.test.ts
+++ b/typescript/test/integration/hedera/submit-topic-message.integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
-import { Client } from '@hashgraph/sdk';
+import { Client, TransactionRecordQuery } from '@hashgraph/sdk';
 import submitTopicMessageTool from '@/plugins/core-consensus-plugin/tools/consensus/submit-topic-message';
 import { Context, AgentMode } from '@/shared/configuration';
 import { getOperatorClientForTests, HederaOperationsWrapper } from '../../utils';
@@ -45,6 +45,7 @@ describe('Submit Topic Message Integration Tests', () => {
     const params: z.infer<ReturnType<typeof submitTopicMessageParameters>> = {
       topicId,
       message: 'hello from integration test',
+      transactionMemo: 'integration tx memo',
     };
 
     const result: any = await tool.execute(operatorClient, context, params);
@@ -62,6 +63,10 @@ describe('Submit Topic Message Integration Tests', () => {
         m => Buffer.from(m.message, 'base64').toString('utf8') === params.message,
       ),
     ).toBeTruthy();
+    const record = await new TransactionRecordQuery()
+      .setTransactionId(result.raw.transactionId)
+      .execute(operatorClient);
+    expect(record.transactionMemo).toBe(params.transactionMemo);
   });
 
   it('fails with invalid topic id', async () => {

--- a/typescript/test/integration/tool-matching/create-topic-tool-matching.integration.test.ts
+++ b/typescript/test/integration/tool-matching/create-topic-tool-matching.integration.test.ts
@@ -62,6 +62,7 @@ describe('Create Topic Tool Matching Integration Tests', () => {
         { input: 'Open a new consensus topic', expected: {} },
         { input: 'Create topic with memo "My memo"', expected: { topicMemo: 'My memo' } },
         { input: 'Create topic and set submit key', expected: { isSubmitKey: true } },
+        { input: 'Create topic with transaction memo "TX: memo"', expected: { transactionMemo: 'TX: memo' } },
       ];
 
       const hederaAPI = toolkit.getHederaAgentKitAPI();


### PR DESCRIPTION
**Description**:
Add integration tests covering `transactionMemo` field behavior during submit message and topic creation.  

**Related issue(s)**:

Depends on #303 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
