### PR TITLE
docs: updated readmefile to support latest langchain version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 > Build Hedera-powered AI agents **in under a minute**.
 
-
-
 ## 📋 Contents
 
 - [Key Features](#key-features)
@@ -19,16 +17,20 @@
 - [Hedera Plugins & Tools](#hedera-plugins--tools)
 - [Creating Plugins & Contributing](#creating-plugins--contributing)
 - [License](#license)
-- [Credits](#credits)   
+- [Credits](#credits)
 
 ---
+
 ## Key Features
+
 This version of the Hedera Agent Kit, known as v3, is a complete rewrite of the original version. It is designed to be more flexible and easier to use, with a focus on developer experience. It enables direct API execution through a simple HederaAgentAPI class, with an individual LangChain tools call for each example.
 
 The Hedera Agent Kit is extensible with third party plugins by other projects.
 
 ---
+
 ## Agent Kit Functionality
+
 The list of currently available Hedera plugins and functionality can be found in the [Plugins & Tools section](#hedera-plugins--tools) of this page
 
 👉 See [docs/PLUGINS.md](docs/PLUGINS.md) for the full catalogue & usage examples.
@@ -43,37 +45,43 @@ Want to add more functionality from Hedera Services? [Open an issue](https://git
 
   Github repository: https://github.com/buidler-labs/hak-memejob-plugin
 
-
 ---
+
 ## Developer Examples
+
 You can try out examples of the different types of agents you can build by followin the instructions in the [Developer Examples](docs/DEVEXAMPLES.md) doc in this repo.
 
 First follow instructions in the [Developer Examples to clone and configure the example](docs/DEVEXAMPLES.md), then choose from one of the examples to run:
 
-* **Option A -** [Example Tool Calling Agent](docs/DEVEXAMPLES.md#option-a-run-the-example-tool-calling-agent)
-* **Option B -** [Example Structured Chat Agent](docs/DEVEXAMPLES.md#option-b-run-the-structured-chat-agent)
-* **Option C -** [Example Return Bytes Agent](docs/DEVEXAMPLES.md#option-c-try-the-human-in-the-loop-chat-agent)
-* **Option D -** [Example MCP Server](docs/DEVEXAMPLES.md#option-d-try-out-the-mcp-server)
-* **Option E -** [Example ElizaOS Agent](docs/DEVEXAMPLES.md#option-e-try-out-the-hedera-agent-kit-with-elizaos)
+- **Option A -** [Example Tool Calling Agent](docs/DEVEXAMPLES.md#option-a-run-the-example-tool-calling-agent)
+- **Option B -** [Example Structured Chat Agent](docs/DEVEXAMPLES.md#option-b-run-the-structured-chat-agent)
+- **Option C -** [Example Return Bytes Agent](docs/DEVEXAMPLES.md#option-c-try-the-human-in-the-loop-chat-agent)
+- **Option D -** [Example MCP Server](docs/DEVEXAMPLES.md#option-d-try-out-the-mcp-server)
+- **Option E -** [Example ElizaOS Agent](docs/DEVEXAMPLES.md#option-e-try-out-the-hedera-agent-kit-with-elizaos)
 
 ---
 
 ## 🚀 60-Second Quick-Start
+
 See more info at [https://www.npmjs.com/package/hedera-agent-kit](https://www.npmjs.com/package/hedera-agent-kit)
 
 ### 🆓 Free AI Options Available!
+
 - **Ollama**: 100% free, runs on your computer, no API key needed
 - **[Groq](https://console.groq.com/keys)**: Offers generous free tier with API key
 - **[Claude](https://console.anthropic.com/settings/keys) & [OpenAI](https://platform.openai.com/api-keys)**: Paid options for production use
 
 ### 1 – Project Setup
+
 Create a directory for your project and install dependencies:
+
 ```bash
 mkdir hello-hedera-agent-kit
 cd hello-hedera-agent-kit
 ```
 
 Init and install with npm
+
 ```bash
 npm init -y
 ```
@@ -85,6 +93,7 @@ npm install hedera-agent-kit @langchain/core langchain @hashgraph/sdk dotenv
 ```
 
 Then install ONE of these AI provider packages:
+
 ```bash
 # Option 1: OpenAI (requires API key)
 npm install @langchain/openai
@@ -99,20 +108,26 @@ npm install @langchain/groq
 npm install @langchain/ollama
 ```
 
+### 2 – Configure: Add Environment Variables
 
-### 2 – Configure: Add Environment Variables 
 Create an `.env` file in the root directory of your project:
+
 ```bash
 touch .env
 ```
 
-If you already have a **testnet** account, you can use it. Otherwise, you can create a new one at [https://portal.hedera.com/dashboard](https://portal.hedera.com/dashboard) 
+If you already have a **testnet** account, you can use it. Otherwise, you can create a new one at [https://portal.hedera.com/dashboard](https://portal.hedera.com/dashboard)
 
 Add the following to the .env file:
+
 ```env
 # Required: Hedera credentials (get free testnet account at https://portal.hedera.com/dashboard)
+# You can use either ACCOUNT_ID/PRIVATE_KEY or HEDERA_ACCOUNT_ID/HEDERA_PRIVATE_KEY
 ACCOUNT_ID="0.0.xxxxx"
 PRIVATE_KEY="0x..." # ECDSA encoded private key
+# Alternative naming:
+# HEDERA_ACCOUNT_ID="0.0.xxxxx"
+# HEDERA_PRIVATE_KEY="0x..."
 
 # Optional: Add the API key for your chosen AI provider
 OPENAI_API_KEY="sk-proj-..."      # For OpenAI (https://platform.openai.com/api-keys)
@@ -121,8 +136,8 @@ GROQ_API_KEY="gsk_..."            # For Groq free tier (https://console.groq.com
 # Ollama doesn't need an API key (runs locally)
 ```
 
-
 ### 3 – Simple "Hello Hedera Agent Kit" Example
+
 Create a a new file called `index.js` in the `hello-hedera-agent-kit` folder.
 
 ```bash
@@ -133,45 +148,67 @@ Once you have created a new file `index.js` and added the environment variables,
 
 ```javascript
 // index.js
-const dotenv = require('dotenv');
+const dotenv = require("dotenv");
 dotenv.config();
 
-const { ChatPromptTemplate } = require('@langchain/core/prompts');
-const { AgentExecutor, createToolCallingAgent } = require('langchain/agents');
-const { Client, PrivateKey } = require('@hashgraph/sdk');
-const { HederaLangchainToolkit, coreQueriesPlugin } = require('hedera-agent-kit');
+const { ChatPromptTemplate } = require("@langchain/core/prompts");
+const {
+  createOpenAIToolsAgent,
+  createToolCallingAgent,
+  AgentExecutor,
+} = require("langchain/agents");
+const { Client, PrivateKey } = require("@hashgraph/sdk");
+const {
+  HederaLangchainToolkit,
+  coreQueriesPlugin,
+} = require("hedera-agent-kit");
 
 // Choose your AI provider (install the one you want to use)
 function createLLM() {
   // Option 1: OpenAI (requires OPENAI_API_KEY in .env)
   if (process.env.OPENAI_API_KEY) {
-    const { ChatOpenAI } = require('@langchain/openai');
-    return new ChatOpenAI({ model: 'gpt-4o-mini' });
+    const { ChatOpenAI } = require("@langchain/openai");
+    return new ChatOpenAI({
+      modelName: "gpt-4o-mini",
+      temperature: 0,
+      openAIApiKey: process.env.OPENAI_API_KEY,
+    });
   }
-  
+
   // Option 2: Anthropic Claude (requires ANTHROPIC_API_KEY in .env)
   if (process.env.ANTHROPIC_API_KEY) {
-    const { ChatAnthropic } = require('@langchain/anthropic');
-    return new ChatAnthropic({ model: 'claude-3-haiku-20240307' });
+    const { ChatAnthropic } = require("@langchain/anthropic");
+    return new ChatAnthropic({
+      model: "claude-3-haiku-20240307",
+      temperature: 0,
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    });
   }
-  
+
   // Option 3: Groq (requires GROQ_API_KEY in .env)
   if (process.env.GROQ_API_KEY) {
-    const { ChatGroq } = require('@langchain/groq');
-    return new ChatGroq({ model: 'llama-3.3-70b-versatile' });
+    const { ChatGroq } = require("@langchain/groq");
+    return new ChatGroq({
+      model: "llama-3.3-70b-versatile",
+      temperature: 0,
+      apiKey: process.env.GROQ_API_KEY,
+    });
   }
-  
+
   // Option 4: Ollama (free, local - requires Ollama installed and running)
   try {
-    const { ChatOllama } = require('@langchain/ollama');
-    return new ChatOllama({ 
-      model: 'llama3.2',
-      baseUrl: 'http://localhost:11434'
+    const { ChatOllama } = require("@langchain/ollama");
+    return new ChatOllama({
+      model: "llama3.2",
+      baseUrl: "http://localhost:11434",
+      temperature: 0,
     });
   } catch (e) {
-    console.error('No AI provider configured. Please either:');
-    console.error('1. Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GROQ_API_KEY in .env');
-    console.error('2. Install and run Ollama locally (https://ollama.com)');
+    console.error("No AI provider configured. Please either:");
+    console.error(
+      "1. Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GROQ_API_KEY in .env"
+    );
+    console.error("2. Install and run Ollama locally (https://ollama.com)");
     process.exit(1);
   }
 }
@@ -181,43 +218,55 @@ async function main() {
   const llm = createLLM();
 
   // Hedera client setup (Testnet by default)
+  // Note: You can use either ACCOUNT_ID/PRIVATE_KEY or HEDERA_ACCOUNT_ID/HEDERA_PRIVATE_KEY
+  const accountId = process.env.HEDERA_ACCOUNT_ID || process.env.ACCOUNT_ID;
+  const privateKey = process.env.HEDERA_PRIVATE_KEY || process.env.PRIVATE_KEY;
+
   const client = Client.forTestnet().setOperator(
-    process.env.ACCOUNT_ID,
-    PrivateKey.fromStringECDSA(process.env.PRIVATE_KEY),
+    accountId,
+    PrivateKey.fromStringECDSA(privateKey)
   );
 
   const hederaAgentToolkit = new HederaLangchainToolkit({
     client,
     configuration: {
-      plugins: [coreQueriesPlugin] // all our core plugins here https://github.com/hedera-dev/hedera-agent-kit/tree/main/typescript/src/plugins
+      plugins: [coreQueriesPlugin], // all our core plugins here https://github.com/hedera-dev/hedera-agent-kit/tree/main/typescript/src/plugins
     },
   });
-  
-  // Load the structured chat prompt template
-  const prompt = ChatPromptTemplate.fromMessages([
-    ['system', 'You are a helpful assistant'],
-    ['placeholder', '{chat_history}'],
-    ['human', '{input}'],
-    ['placeholder', '{agent_scratchpad}'],
-  ]);
 
   // Fetch tools from toolkit
   const tools = hederaAgentToolkit.getTools();
 
-  // Create the underlying agent
-  const agent = createToolCallingAgent({
-    llm,
-    tools,
-    prompt,
-  });
-  
-  // Wrap everything in an executor that will maintain memory
-  const agentExecutor = new AgentExecutor({
+  // Create the agent using the LangChain v1.0.1+ API
+  // Note: createOpenAIToolsAgent works best with OpenAI models
+  // For other providers (Claude, Groq, Ollama), use createToolCallingAgent instead
+  const isOpenAI = process.env.OPENAI_API_KEY;
+
+  const prompt = ChatPromptTemplate.fromMessages([
+    [
+      "system",
+      "You are a helpful assistant that can interact with the Hedera network.",
+    ],
+    ["human", "{input}"],
+    ["placeholder", "{agent_scratchpad}"],
+  ]);
+
+  const agent = isOpenAI
+    ? await createOpenAIToolsAgent({ llm, tools, prompt })
+    : await createToolCallingAgent({ llm, tools, prompt });
+
+  // Create executor to run the agent
+  const executor = new AgentExecutor({
     agent,
     tools,
+    verbose: true,
   });
-  
-  const response = await agentExecutor.invoke({ input: "what's my balance?" });
+
+  // Invoke the agent
+  const response = await executor.invoke({
+    input: "what's my balance?",
+  });
+
   console.log(response);
 }
 
@@ -225,16 +274,17 @@ main().catch(console.error);
 ```
 
 ### 4 – Run Your "Hello Hedera Agent Kit" Example
+
 From the root directory, run your example agent, and prompt it to give your hbar balance:
 
 ```bash
 node index.js
 ```
 
-If you would like, try adding in other prompts to the agent to see what it can do. 
+If you would like, try adding in other prompts to the agent to see what it can do.
 
 ```javascript
-... 
+...
 //original
   const response = await agentExecutor.invoke({ input: "what's my balance?" });
 // or
@@ -246,6 +296,7 @@ If you would like, try adding in other prompts to the agent to see what it can d
 ...
    console.log(response);
 ```
+
 > To get other Hedera Agent Kit tools working, take a look at the example agent implementations at [https://github.com/hedera-dev/hedera-agent-kit/tree/main/typescript/examples/langchain](https://github.com/hedera-dev/hedera-agent-kit/tree/main/typescript/examples/langchain)
 
 ---
@@ -253,11 +304,14 @@ If you would like, try adding in other prompts to the agent to see what it can d
 ## About the Agent Kit
 
 ### Agent Execution Modes
-This tool has two execution modes with AI agents;  autonomous excution and return bytes. If you set:
- * `mode: AgentMode.RETURN_BYTE` the transaction will be executed, and the bytes to execute the Hedera transaction will be returned. 
- * `mode: AgentMode.AUTONOMOUS` the transaction will be executed autonomously, using the accountID set (the operator account can be set in the client with `.setOperator(process.env.ACCOUNT_ID!`)
+
+This tool has two execution modes with AI agents; autonomous excution and return bytes. If you set:
+
+- `mode: AgentMode.RETURN_BYTE` the transaction will be executed, and the bytes to execute the Hedera transaction will be returned.
+- `mode: AgentMode.AUTONOMOUS` the transaction will be executed autonomously, using the accountID set (the operator account can be set in the client with `.setOperator(process.env.ACCOUNT_ID!`)
 
 ### Hedera Plugins & Tools
+
 The Hedera Agent Kit provides a set of tools, bundled into plugins, to interact with the Hedera network. See how to build your own plugins in [docs/HEDERAPLUGINS.md](docs/HEDERAPLUGINS.md)
 
 Currently, the following plugins are available:
@@ -265,35 +319,43 @@ Currently, the following plugins are available:
 #### Available Plugins & Tools
 
 #### Core Account Plugin: Tools for Hedera Account Service operations
-* Transfer HBAR
-#### Core Consensus Plugin: Tools for Hedera Consensus Service (HCS) operations 
-* Create a Topic
-* Submit a message to a Topic 
+
+- Transfer HBAR
+
+#### Core Consensus Plugin: Tools for Hedera Consensus Service (HCS) operations
+
+- Create a Topic
+- Submit a message to a Topic
+
 #### Core HTS Plugin: Tools for Hedera Token Service operations
-* Create a Fungible Token
-* Create a Non-Fungible Token
-* Airdrop Fungible Tokens
+
+- Create a Fungible Token
+- Create a Non-Fungible Token
+- Airdrop Fungible Tokens
 
 #### Core Queries Plugin: Tools for querying Hedera network data
-* Get Account Query
-* Get HBAR Balance Query
-* Get Account Token Balances Query
-* Get Topic Messages Query
 
+- Get Account Query
+- Get HBAR Balance Query
+- Get Account Token Balances Query
+- Get Topic Messages Query
 
 _See more in [docs/PLUGINS.md](docs/PLUGINS.md)_
 
 ---
 
 ## Creating Plugins & Contributing
-* You can find a guide for creating plugins in [docs/PLUGINS.md](docs/PLUGINS.md)
 
-* This guide also has instructions for [publishing and registering your plugin](docs/PLUGINS.md#publish-and-register-your-plugin) to help our community find and use it.
+- You can find a guide for creating plugins in [docs/PLUGINS.md](docs/PLUGINS.md)
 
-* If you would like to contribute and suggest improvements for the cord SDK and MCP server, see [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to contribute to the Hedera Agent Kit.
+- This guide also has instructions for [publishing and registering your plugin](docs/PLUGINS.md#publish-and-register-your-plugin) to help our community find and use it.
+
+- If you would like to contribute and suggest improvements for the cord SDK and MCP server, see [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to contribute to the Hedera Agent Kit.
 
 ## License
+
 Apache 2.0
 
 ## Credits
+
 Special thanks to the developers of the [Stripe Agent Toolkit](https://github.com/stripe/agent-toolkit) who provided the inspiration for the architecture and patterns used in this project.


### PR DESCRIPTION
**Description**:

This PR updates the README.md quick-start example to use the current LangChain v1.0.1+ API in order to ensure the documentation matches working code implementations and provides accurate examples for new users.

The previous example used deprecated LangChain patterns that no longer work with current versions. This update aligns the documentation with the actual working implementation and maintains backward compatibility with multiple AI providers.

* Replace `createToolCallingAgent` with `createOpenAIToolsAgent` for OpenAI models
* Add conditional logic to use `createOpenAIToolsAgent` for OpenAI and `createToolCallingAgent` for other providers (Claude, Groq, Ollama)
* Update `ChatOpenAI` initialization to explicitly use `modelName` and `openAIApiKey` parameters
* Remove `chat_history` placeholder from prompt template to match current working demo structure
* Add `verbose: true` to `AgentExecutor` for better debugging output
* Support both `ACCOUNT_ID`/`PRIVATE_KEY` and `HEDERA_ACCOUNT_ID`/`HEDERA_PRIVATE_KEY` environment variable naming conventions
* Add `await` keyword for agent creation (required in LangChain v1.0.1+)
* Update prompt structure to match current LangChain API patterns


**Notes for reviewer**:

The changes have been tested against a working implementation and verified to match the current LangChain API. The example code:
- Works with OpenAI using `createOpenAIToolsAgent`
- Maintains compatibility with Claude, Groq, and Ollama using `createToolCallingAgent`
- Supports flexible environment variable naming
- Follows the same structure as the working demo in the codebase

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.) - Verified against working implementation


