### PR TITLE
docs: added pyth-plugin to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Want to add more functionality from Hedera Services? [Open an issue](https://git
 
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
 
-  Github repository: https://github.com/jmgomezl/hak-pyth-plugin
+  Github repository: [https://github.com/jmgomezl/hak-pyth-plugin](https://github.com/jmgomezl/hak-pyth-plugin).
+  Tested/endorsed version of plugin: hak-pyth-plugin@0.1.1
 
 - [CoinCap Plugin](https://www.npmjs.com/package/coincap-hedera-plugin) provides access to the [**CoinCap API service**](https://www.coincap.io) to access cryptocurrency market data. It exposes the action (`get HBAR price in USD`) to get the current price of HBAR in USD currency, by using it you can ask your agent to get your current HBAR balance expressed in USD.
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -13,7 +13,8 @@ The Hedera services built into this agent toolkit are also implemented as plugin
 
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
 
-  Github repository: https://github.com/jmgomezl/hak-pyth-plugin
+  Github repository: [https://github.com/jmgomezl/hak-pyth-plugin](https://github.com/jmgomezl/hak-pyth-plugin).
+  Tested/endorsed version of plugin: hak-pyth-plugin@0.1.1
 
 ## Plugin Architecture
 


### PR DESCRIPTION
## Summary
- Register the Pyth plugin in the third-party plugin lists
- Link to the npm package and GitHub repo
- Include the core tool list exposed by the plugin

## Release
- Published as hak-pyth-plugin@0.1.1

## Testing
- Not run (docs-only change)

##Author
@jmgomezl