### PR TITLE
refactor: remove redundant Client references from hook interfaces

### DIFF
--- a/typescript/src/shared/abstract-hook.ts
+++ b/typescript/src/shared/abstract-hook.ts
@@ -44,7 +44,6 @@ export abstract class AbstractHook {
     _context: Context,
     _params: PreToolExecutionParams,
     method: string,
-    _client: Client,
   ): Promise<any> {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
   }
@@ -53,7 +52,6 @@ export abstract class AbstractHook {
     _context: Context,
     _params: PostParamsNormalizationParams,
     method: string,
-    _client: Client,
   ): Promise<any> {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
   }
@@ -62,7 +60,6 @@ export abstract class AbstractHook {
     _context: Context,
     _params: PostCoreActionParams,
     method: string,
-    _client: Client,
   ): Promise<any> {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
   }
@@ -71,7 +68,6 @@ export abstract class AbstractHook {
     _context: Context,
     _params: PostSecondaryActionParams,
     method: string,
-    _client: Client,
   ): Promise<any> {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
   }

--- a/typescript/src/shared/hooks/hcs-audit-trail-hook.ts
+++ b/typescript/src/shared/hooks/hcs-audit-trail-hook.ts
@@ -3,10 +3,9 @@ import { AgentMode, Context } from '@/shared';
 import { RawTransactionResponse } from '@/shared';
 import { Client, TopicMessageSubmitTransaction } from '@hashgraph/sdk';
 
-
 /**
  * Hook to add an audit trail of tool executions to a Hedera Consensus Service (HCS) topic.
- * 
+ *
  * @warning If a paid topic (HIP-991: https://hips.hedera.com/hip/hip-991) is provided,
  * it could potentially drain the provided logging client's funds due to message submission fees.
  */
@@ -31,7 +30,6 @@ export class HcsAuditTrailHook extends AbstractHook {
     context: Context,
     _params: PreToolExecutionParams,
     method: string,
-    _client: Client,
   ): Promise<any> {
     if (!this.relevantTools.includes(method)) return;
 
@@ -50,7 +48,6 @@ export class HcsAuditTrailHook extends AbstractHook {
     _context: Context,
     params: PostSecondaryActionParams,
     method: string,
-    client: Client,
   ): Promise<any> {
     if (!this.relevantTools.includes(method)) return;
 
@@ -61,7 +58,7 @@ export class HcsAuditTrailHook extends AbstractHook {
       console.log(
         `HcsAuditTrailHook: No logging specific client provided. Using the agent's operator account client.`,
       );
-      targetClient = client;
+      targetClient = params.client;
     }
 
     const logMessage: string = `Agent executed tool ${method} on with params ${JSON.stringify(params.normalisedParams)}.

--- a/typescript/src/shared/policies/reject-tool-policy.ts
+++ b/typescript/src/shared/policies/reject-tool-policy.ts
@@ -1,5 +1,4 @@
 import { Policy, Context, PreToolExecutionParams } from '@/shared';
-import { Client } from '@hashgraph/sdk';
 
 export class RejectToolPolicy extends Policy {
   name = 'Reject Tool Call';
@@ -18,7 +17,6 @@ export class RejectToolPolicy extends Policy {
   protected shouldBlockPreToolExecution(
     _context: Context,
     _params: PreToolExecutionParams,
-    _client: Client,
   ): boolean {
     console.log('RejectToolPolicy: tool call rejected - tool not allowed');
     return true;

--- a/typescript/src/shared/policy.ts
+++ b/typescript/src/shared/policy.ts
@@ -6,7 +6,6 @@ import {
   PostCoreActionParams,
   PostSecondaryActionParams,
 } from './abstract-hook';
-import { Client } from '@hashgraph/sdk';
 
 /**
  * Policy extends Hook and throws errors when validation fails.
@@ -23,7 +22,6 @@ export abstract class Policy extends AbstractHook {
   protected shouldBlockPreToolExecution(
     _context: Context,
     _params: PreToolExecutionParams,
-    _client: Client,
   ): boolean | Promise<boolean> {
     return false;
   }
@@ -35,7 +33,6 @@ export abstract class Policy extends AbstractHook {
   protected shouldBlockPostParamsNormalization(
     _context: Context,
     _params: PostParamsNormalizationParams,
-    _client: Client,
   ): boolean | Promise<boolean> {
     return false;
   }
@@ -47,7 +44,6 @@ export abstract class Policy extends AbstractHook {
   protected shouldBlockPostCoreAction(
     _context: Context,
     _params: PostCoreActionParams,
-    _client: Client,
   ): boolean | Promise<boolean> {
     return false;
   }
@@ -59,7 +55,6 @@ export abstract class Policy extends AbstractHook {
   protected shouldBlockPostSecondaryAction(
     _context: Context,
     _params: PostSecondaryActionParams,
-    _client: Client,
   ): boolean | Promise<boolean> {
     return false;
   }
@@ -70,10 +65,9 @@ export abstract class Policy extends AbstractHook {
     context: Context,
     params: PreToolExecutionParams,
     method: string,
-    client: Client,
   ): Promise<void> {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
-    const shouldBlock = await this.shouldBlockPreToolExecution(context, params, client);
+    const shouldBlock = await this.shouldBlockPreToolExecution(context, params);
     if (shouldBlock) {
       throw new Error(
         `Action ${method} blocked by policy: ${this.name}${this.description ? ` (${this.description})` : ''}`,
@@ -86,10 +80,9 @@ export abstract class Policy extends AbstractHook {
     context: Context,
     params: PostParamsNormalizationParams,
     method: string,
-    client: Client,
   ): Promise<void> {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
-    const shouldBlock = await this.shouldBlockPostParamsNormalization(context, params, client);
+    const shouldBlock = await this.shouldBlockPostParamsNormalization(context, params);
     if (shouldBlock) {
       throw new Error(
         `Action ${method} blocked by policy: ${this.name}${this.description ? ` (${this.description})` : ''}`,
@@ -102,10 +95,9 @@ export abstract class Policy extends AbstractHook {
     context: Context,
     params: PostCoreActionParams,
     method: string,
-    client: Client,
   ): Promise<void> {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
-    const shouldBlock = await this.shouldBlockPostCoreAction(context, params, client);
+    const shouldBlock = await this.shouldBlockPostCoreAction(context, params);
     if (shouldBlock) {
       throw new Error(
         `Action ${method} blocked by policy: ${this.name}${this.description ? ` (${this.description})` : ''}`,
@@ -118,10 +110,9 @@ export abstract class Policy extends AbstractHook {
     context: Context,
     params: PostSecondaryActionParams,
     method: string,
-    client: Client,
   ): Promise<void> {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
-    const shouldBlock = await this.shouldBlockPostSecondaryAction(context, params, client);
+    const shouldBlock = await this.shouldBlockPostSecondaryAction(context, params);
     if (shouldBlock) {
       throw new Error(
         `Action ${method} blocked by policy: ${this.name}${this.description ? ` (${this.description})` : ''}`,

--- a/typescript/src/shared/tools.ts
+++ b/typescript/src/shared/tools.ts
@@ -36,7 +36,12 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
       const normalisedParams = await this.normalizeParams(params, context, client);
 
       // 3. PostParamsNormalizationHook
-      await this.postParamsNormalizationHook({ context, rawParams: params, normalisedParams, client });
+      await this.postParamsNormalizationHook({
+        context,
+        rawParams: params,
+        normalisedParams,
+        client,
+      });
 
       // 4. Core Action (Core Tool Logic)
       const coreActionResult = await this.coreAction(normalisedParams, context, client); // transactions will be created here
@@ -47,7 +52,7 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
         rawParams: params,
         normalisedParams,
         coreActionResult,
-        client
+        client,
       });
 
       // 6. Secondary Action (Optional)
@@ -63,7 +68,7 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
         normalisedParams,
         coreActionResult,
         toolResult: result,
-        client
+        client,
       });
     } catch (error) {
       return this.handleError(error, context);
@@ -73,7 +78,7 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
   // Hooks
   async preToolExecutionHook(params: PreToolExecutionParams<TParams>): Promise<void> {
     await this.executeHooks(params.context, async (h, method) =>
-      h.preToolExecutionHook(params.context, params, method, params.client),
+      h.preToolExecutionHook(params.context, params, method),
     );
   }
 
@@ -81,7 +86,7 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
     params: PostParamsNormalizationParams<TParams, TNormalisedParams>,
   ): Promise<void> {
     await this.executeHooks(params.context, async (h, method) =>
-      h.postParamsNormalizationHook(params.context, params, method, params.client),
+      h.postParamsNormalizationHook(params.context, params, method),
     );
   }
 
@@ -89,7 +94,7 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
     params: PostCoreActionParams<TParams, TNormalisedParams>,
   ): Promise<void> {
     await this.executeHooks(params.context, async (h, method) =>
-      h.postCoreActionHook(params.context, params, method, params.client),
+      h.postCoreActionHook(params.context, params, method),
     );
   }
 
@@ -104,7 +109,7 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
     params: PostSecondaryActionParams<TParams, TNormalisedParams>,
   ): Promise<any> {
     await this.executeHooks(params.context, async (h, method) =>
-      h.postToolExecutionHook(params.context, params, method, params.client),
+      h.postToolExecutionHook(params.context, params, method),
     );
     return params.toolResult;
   }

--- a/typescript/test/unit/hooks/hcs-audit-trail-hook.unit.test.ts
+++ b/typescript/test/unit/hooks/hcs-audit-trail-hook.unit.test.ts
@@ -62,16 +62,16 @@ describe('HcsAuditTrailHook Unit Tests', () => {
   it('should not log or throw if method is not relevant', async () => {
     const operatorClient = {} as Client;
     const context = { mode: AgentMode.RETURN_BYTES };
-    const preParams = {} as PreToolExecutionParams;
+    const preParams = { client: operatorClient } as PreToolExecutionParams;
     const postParams = { normalisedParams: {} } as PostSecondaryActionParams;
 
     const postMessageSpy = vi.spyOn(hook, 'postMessageToHcsTopic');
 
     // Neither pre- nor post-hook should throw or log for a non-relevant tool
     await expect(
-      hook.preToolExecutionHook(context, preParams, 'other_tool', operatorClient),
+      hook.preToolExecutionHook(context, preParams, 'other_tool'),
     ).resolves.toBeUndefined();
-    await hook.postToolExecutionHook(context, postParams, 'other_tool', operatorClient);
+    await hook.postToolExecutionHook(context, postParams, 'other_tool');
 
     expect(postMessageSpy).not.toHaveBeenCalled();
   });
@@ -79,11 +79,9 @@ describe('HcsAuditTrailHook Unit Tests', () => {
   it('should throw if mode is RETURN_BYTES in preToolExecutionHook', async () => {
     const operatorClient = {} as Client;
     const context = { mode: AgentMode.RETURN_BYTES };
-    const params = {} as PreToolExecutionParams;
+    const params = { client: operatorClient } as PreToolExecutionParams;
 
-    await expect(
-      hook.preToolExecutionHook(context, params, 'test_tool', operatorClient),
-    ).rejects.toThrow(
+    await expect(hook.preToolExecutionHook(context, params, 'test_tool')).rejects.toThrow(
       'Unsupported hook: HcsAuditTrailHook is available only in Agent Mode AUTONOMOUS. Stopping the agent execution before tool test_tool is executed.',
     );
   });
@@ -94,6 +92,7 @@ describe('HcsAuditTrailHook Unit Tests', () => {
     const params = {
       normalisedParams: { amount: 100 },
       toolResult: { raw: {} as RawTransactionResponse },
+      client: operatorClient,
     } as PostSecondaryActionParams;
 
     const hookWithoutClient = new HcsAuditTrailHook(relevantTools, topicId);
@@ -101,7 +100,7 @@ describe('HcsAuditTrailHook Unit Tests', () => {
       .spyOn(hookWithoutClient, 'postMessageToHcsTopic')
       .mockImplementation(async () => {});
 
-    await hookWithoutClient.postToolExecutionHook(context, params, 'test_tool', operatorClient);
+    await hookWithoutClient.postToolExecutionHook(context, params, 'test_tool');
 
     expect(postMessageSpy).toHaveBeenCalledTimes(1);
     expect(postMessageSpy).toHaveBeenCalledWith(
@@ -115,6 +114,7 @@ describe('HcsAuditTrailHook Unit Tests', () => {
     const context = { mode: AgentMode.AUTONOMOUS };
     const params = {
       normalisedParams: { amount: 100 },
+      client: operatorClient,
       toolResult: {
         raw: {
           transactionId: '0.0.1@123',
@@ -124,7 +124,7 @@ describe('HcsAuditTrailHook Unit Tests', () => {
       },
     } as PostSecondaryActionParams;
 
-    await hook.postToolExecutionHook(context, params, 'test_tool', operatorClient);
+    await hook.postToolExecutionHook(context, params, 'test_tool');
 
     const TopicMessageSubmitTransactionMock = sdk.TopicMessageSubmitTransaction as any;
     expect(TopicMessageSubmitTransactionMock).toHaveBeenCalled();


### PR DESCRIPTION
**Description**:
removed redundand client parameter in hooks and refactored related logic.
Tested with the unit/integration/e2e tests

**Related issue(s)**:

Related #416

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
