### PR TITLE
chore: bump HAK package version to 3.8.1 in examples

### DIFF
--- a/typescript/examples/ai-sdk/package-lock.json
+++ b/typescript/examples/ai-sdk/package-lock.json
@@ -14,7 +14,7 @@
         "@modelcontextprotocol/sdk": "1.26.0",
         "ai": "^6.0.86",
         "dotenv": "17.2.3",
-        "hedera-agent-kit": "../..",
+        "hedera-agent-kit": "3.8.1",
         "prompts": "2.4.2",
         "zod": "^3.23.8"
       },
@@ -26,7 +26,7 @@
     },
     "../..": {
       "name": "hedera-agent-kit",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/mcp": "1.0.21",

--- a/typescript/examples/ai-sdk/package.json
+++ b/typescript/examples/ai-sdk/package.json
@@ -15,7 +15,7 @@
     "ai": "^6.0.86",
     "dotenv": "17.2.3",
     "zod": "^3.23.8",
-    "hedera-agent-kit": "../..",
+    "hedera-agent-kit": "3.8.1",
     "prompts": "2.4.2"
   },
   "author": "",

--- a/typescript/examples/langchain-v1/package-lock.json
+++ b/typescript/examples/langchain-v1/package-lock.json
@@ -12,7 +12,7 @@
         "@langchain/core": "1.1.24",
         "@langchain/mcp-adapters": "^1.1.3",
         "dotenv": "17.2.3",
-        "hedera-agent-kit": "../..",
+        "hedera-agent-kit": "3.8.1",
         "langchain": "1.2.24",
         "prompts": "2.4.2"
       },
@@ -24,7 +24,7 @@
     },
     "../..": {
       "name": "hedera-agent-kit",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/mcp": "1.0.21",

--- a/typescript/examples/langchain-v1/package.json
+++ b/typescript/examples/langchain-v1/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@hashgraph/sdk": "2.80.0",
-    "hedera-agent-kit": "../..",
+    "hedera-agent-kit": "3.8.1",
     "@langchain/core": "1.1.24",
     "@langchain/mcp-adapters": "^1.1.3",
     "dotenv": "17.2.3",

--- a/typescript/examples/langchain/package-lock.json
+++ b/typescript/examples/langchain/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../..": {
       "name": "hedera-agent-kit",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/mcp": "1.0.21",

--- a/typescript/examples/langchain/package.json
+++ b/typescript/examples/langchain/package.json
@@ -16,7 +16,7 @@
     "@langchain/openai": "1.2.7",
     "cheerio": "1.1.2",
     "dotenv": "17.2.3",
-    "hedera-agent-kit": "../..",
+    "hedera-agent-kit": "3.8.1",
     "prompts": "2.4.2"
   },
   "author": "",

--- a/typescript/examples/nextjs/package-lock.json
+++ b/typescript/examples/nextjs/package-lock.json
@@ -28,7 +28,7 @@
         "@walletconnect/universal-provider": "2.21.7",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
-        "hedera-agent-kit": "3.7.1",
+        "hedera-agent-kit": "3.8.1",
         "lucide-react": "0.539.0",
         "next": "15.5.12",
         "next-themes": "0.4.6",
@@ -53,7 +53,7 @@
     },
     "../..": {
       "name": "hedera-agent-kit",
-      "version": "3.7.1",
+      "version": "3.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/mcp": "1.0.21",
@@ -62,7 +62,7 @@
         "@langchain/core": "1.1.24",
         "@langchain/mcp-adapters": "1.1.3",
         "@langchain/openai": "1.2.7",
-        "@modelcontextprotocol/sdk": "1.26.0",
+        "@modelcontextprotocol/sdk": "1.27.1",
         "ai": "6.0.86",
         "bignumber.js": "9.3.1",
         "ethers": "6.15.0",
@@ -1002,9 +1002,9 @@
       }
     },
     "node_modules/@ethersproject/bignumber/node_modules/bn.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "license": "MIT"
     },
     "node_modules/@ethersproject/bytes": {
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/@ethersproject/signing-key/node_modules/bn.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "license": "MIT"
     },
     "node_modules/@ethersproject/strings": {
@@ -5843,13 +5843,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7620,9 +7620,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8963,9 +8963,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -12569,9 +12569,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/typescript/examples/nextjs/package.json
+++ b/typescript/examples/nextjs/package.json
@@ -29,7 +29,7 @@
     "@walletconnect/universal-provider": "2.21.7",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
-    "hedera-agent-kit": "3.7.1",
+    "hedera-agent-kit": "3.8.1",
     "lucide-react": "0.539.0",
     "next": "15.5.12",
     "next-themes": "0.4.6",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hedera-agent-kit",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hedera-agent-kit",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/mcp": "1.0.21",


### PR DESCRIPTION
**Description**:
updates the examples to use the newest and secure version of HAK
Tests manually

**Related issue(s)**:

Fixes #570 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
