### PR TITLE
docs: add MPP Hedera Plugin to third-party plugins

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -97,6 +97,16 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Status: Not validated by HAK team, v3-compatible release
 
+- [MPP Hedera Plugin](https://www.npmjs.com/package/hak-mppx-hedera-plugin) enables AI agents to pay for 402-protected APIs using USDC on Hedera via the [Machine Payments Protocol](https://mpp.dev), exposing tools for one-shot charge payments (`mppx_hedera_charge_fetch_tool`) and streaming session payments (`mppx_hedera_session_open_tool`, `mppx_hedera_session_fetch_tool`, `mppx_hedera_session_close_tool`):
+
+  NPM: https://www.npmjs.com/package/hak-mppx-hedera-plugin
+
+  Github repository: https://github.com/tomrowbo/hak-mppx-hedera-plugin
+
+  Version: hak-mppx-hedera-plugin@1.2.0
+
+  Status: Not validated by HAK team, v4-compatible release
+
 ## Plugin Architecture
 
 The tools are now organized into plugins, each containing a set functionality related to the Hedera service or project they are created for.


### PR DESCRIPTION
## Summary

Adds [hak-mppx-hedera-plugin](https://www.npmjs.com/package/hak-mppx-hedera-plugin) to the third-party plugins list.

This plugin enables AI agents to pay for 402-protected APIs using USDC on Hedera via the [Machine Payments Protocol (MPP)](https://mpp.dev) — the IETF-track HTTP 402 standard co-developed by Stripe and Tempo.

## Tools

| Tool | Description |
|------|-------------|
| `mppx_hedera_charge_fetch_tool` | One-shot: call API, auto-pay with USDC, return data |
| `mppx_hedera_session_open_tool` | Open a payment channel (deposit USDC into escrow) |
| `mppx_hedera_session_fetch_tool` | Call API using open session (off-chain voucher, <1ms, no gas) |
| `mppx_hedera_session_close_tool` | Settle and close channel (refund unused deposit) |

## Links

- **npm**: https://www.npmjs.com/package/hak-mppx-hedera-plugin
- **GitHub**: https://github.com/tomrowbo/hak-mppx-hedera-plugin
- **SDK**: https://www.npmjs.com/package/mppx-hedera
- **Demo**: `node examples/agent-demo.mjs` — real Agent Kit + real Hedera testnet
- **Tests**: 56 unit/integration + E2E with real `HederaAgentAPI` + `ToolDiscovery`

## Context

Discussed with @Lindsay-Walker — this plugin was built based on her suggestion to productionize our hackathon submission (2nd place, Agentic Society Hackathon @ LSE) as an Agent Kit plugin.