### PR TITLE
chore: update 3rd party plugins and docs formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,38 +45,7 @@ Want to add more functionality from Hedera Services? [Open an issue](https://git
 ---
 
 ### Third Party Plugins
-The Hedera Agent Kit is extensible with third party plugins by other projects. See how you can build and submit your own plugin to listed as a Hedera Agent Kit plugin in [Hedera Docs](https://docs.hedera.com/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/hedera-agent-kit-js/plugins) and README in [docs/PLUGINS.md](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/PLUGINS.md) 
-
-- [Memejob Plugin](https://www.npmjs.com/package/@buidlerlabs/hak-memejob-plugin) provides a streamlined interface to the [**memejob**](https://memejob.fun/) protocol, exposing the core actions (`create`, `buy`, `sell`) for interacting with meme tokens on Hedera:
-
-  Github repository: https://github.com/buidler-labs/hak-memejob-plugin
-
-- [Bonzo Plugin](https://www.npmjs.com/package/@bonzofinancelabs/hak-bonzo-plugin) is a unified SDK to the [**Bonzo**](https://bonzo.finance) protocol, exposing the core actions (`deposit`, `withdraw`, `repay`, `borrow`) for decentralised lending and borrowing on Hedera:
-
-  Github repository: [https://github.com/Bonzo-Labs/bonzoPlugin](https://github.com/Bonzo-Labs/bonzoPlugin)
-
-- [SaucerSwap Plugin](https://www.npmjs.com/package/hak-saucerswap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`saucerswap_get_swap_quote`, `saucerswap_swap_tokens`, `saucerswap_get_pools`, `saucerswap_add_liquidity`, `saucerswap_remove_liquidity`, `saucerswap_get_farms`) for swaps, liquidity, and farming insights:
-
-  NPM: https://www.npmjs.com/package/hak-saucerswap-plugin
-  Source: https://github.com/jmgomezl/hak-saucerswap-plugin
-  Tested/endorsed version: hak-saucerswap-plugin@1.0.1
-
-- [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
-
-  Github repository: [https://github.com/jmgomezl/hak-pyth-plugin](https://github.com/jmgomezl/hak-pyth-plugin).
-  Tested/endorsed version of plugin: hak-pyth-plugin@0.1.1
-
-- [CoinCap Plugin](https://www.npmjs.com/package/coincap-hedera-plugin) provides access to the [**CoinCap API service**](https://www.coincap.io) to access cryptocurrency market data. It exposes the action (`get HBAR price in USD`) to get the current price of HBAR in USD currency, by using it you can ask your agent to get your current HBAR balance expressed in USD.
-
-  Github repository: [https://github.com/henrytongv/coincap-hedera-plugin](https://github.com/henrytongv/coincap-hedera-plugin). Tested/endorsed version of plugin: coincap-hedera-plugin@1.0.4
-
-- [Chainlink price feed Plugin](https://www.npmjs.com/package/chainlink-pricefeed-plugin) provides access to the [**Chainlink price feeds**](https://docs.chain.link/data-feeds/price-feeds) to get data aggregated from many data sources. It exposes the action (`get price feed`) that allows you to get the current price for ETH, BTC, HBAR, LINK, USDC, UST or DAI.
-
-  Github repository: [https://github.com/henrytongv/chainlink-price-plugin-js](https://github.com/henrytongv/chainlink-price-plugin-js). Tested/endorsed version of plugin: chainlink-pricefeed-plugin@1.0.4
-
-- [Hedera T3N Plugin](https://www.npmjs.com/package/@terminal3/hedera-t3n-plugin) provides access to [Terminal 3 Network (T3N)](https://docs.terminal3.io/t3n/) to enable identity verification, authentication, and last mile-delivery or selective disclosure of private and sensitive information for AI-driven applications, ensuring compliant and auditable interactions.
-
-  Github repository: [https://github.com/Terminal-3/hedera-t3n-plugin](https://github.com/Terminal-3/hedera-t3n-plugin)
+The Hedera Agent Kit is extensible with third-party plugins developed by other projects. See how you can build and submit your own plugin to be listed as a Hedera Agent Kit plugin in [Hedera Docs](https://docs.hedera.com/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/plugins#plugins) and in [docs/PLUGINS.md](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/PLUGINS.md).
 
 _[Contribute your own plugin](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/PLUGINS.md)_
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,28 +1,68 @@
 # Available Hedera Plugins
 
-The Hedera Agent Kit provides a comprehensive set of tools organized into **plugins**, which can be installed alongside the Hedera Agent Kit and used to extend the core funcitonality of the Hederak Agent Kit SDK.
+The Hedera Agent Kit provides a comprehensive set of tools organized into **plugins**, which can be installed alongside the Hedera Agent Kit and used to extend the core functionality of the Hedera Agent Kit SDK.
 These tools can be used both by the conversational agent and when you are building with the SDK.
 
 The Hedera services built into this agent toolkit are also implemented as plugins, you can see a description of each plugin in the [HEDERAPLUGINS.md](HEDERAPLUGINS.md) file, as well as list of the individual tools for each Hedera service that are included in each plugin.
 
 ## Available Third Party Plugins
 
-See this list of available third party plugins for the Hedera Agent Kit Python SDK in the [README](../README.md) and in the [Hedera Docs](https://docs.hedera.com/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/hedera-agent-kit-js/plugins).
+See this list of available third party plugins for the Hedera Agent Kit in the [Hedera Docs](https://docs.hedera.com/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/plugins#plugins).
 
-- [SaucerSwap Plugin](https://www.npmjs.com/package/hak-saucerswap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`saucerswap_get_swap_quote`, `saucerswap_swap_tokens`, `saucerswap_get_pools`, `saucerswap_add_liquidity`, `saucerswap_remove_liquidity`, `saucerswap_get_farms`) for swaps, liquidity, and farming insights:
 
-  NPM: https://www.npmjs.com/package/hak-saucerswap-plugin
-  Source: https://github.com/jmgomezl/hak-saucerswap-plugin
-  Tested/endorsed version: hak-saucerswap-plugin@1.0.1
+- [Memejob Plugin](https://www.npmjs.com/package/@buidlerlabs/hak-memejob-plugin) provides a streamlined interface to the [**memejob**](https://memejob.fun/) protocol, exposing the core actions (`create`, `buy`, `sell`) for interacting with meme tokens on Hedera:
+
+  NPM: https://www.npmjs.com/package/@buidlerlabs/hak-memejob-plugin
+
+  Github repository: https://github.com/buidler-labs/hak-memejob-plugin
+
+
+- [Bonzo Plugin](https://www.npmjs.com/package/@bonzofinancelabs/hak-bonzo-plugin) is a unified SDK to the [**Bonzo**](https://bonzo.finance) protocol, exposing the core actions (`deposit`, `withdraw`, `repay`, `borrow`) for decentralised lending and borrowing on Hedera:
+
+  NPM: https://www.npmjs.com/package/@bonzofinancelabs/hak-bonzo-plugin
+
+  Github repository: https://github.com/Bonzo-Labs/bonzoPlugin
+
+
+- [SaucerSwap Plugin](https://www.npmjs.com/package/saucer-swap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`get_swap_quote_v2_tool`, `swap_v2_tool`) for executing swaps and obtaining swap quotes.
+
+  NPM: https://www.npmjs.com/package/saucer-swap-plugin
+
+  Github repository: https://github.com/saucerswaplabs/hedera-agent-kit-saucer-swap-plugin
+
+  Tested/endorsed version: saucer-swap-plugin@0.2.0 (migrated to HAK V4)
+
 
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
 
-  Github repository: [https://github.com/jmgomezl/hak-pyth-plugin](https://github.com/jmgomezl/hak-pyth-plugin).
-  Tested/endorsed version of plugin: hak-pyth-plugin@0.1.1
+  NPM: https://www.npmjs.com/package/hak-pyth-plugin
+
+  Github repository: https://github.com/jmgomezl/hak-pyth-plugin
+
+
+
+- [CoinCap Plugin](https://www.npmjs.com/package/coincap-hedera-plugin) provides access to the [**CoinCap API service**](https://www.coincap.io) to access cryptocurrency market data. It exposes the action (`get HBAR price in USD`) to get the current price of HBAR in USD currency, by using it you can ask your agent to get your current HBAR balance expressed in USD.
+
+  NPM: https://www.npmjs.com/package/coincap-hedera-plugin
+
+  Github repository: https://github.com/henrytongv/coincap-hedera-plugin
+
+
+
+- [Chainlink price feed Plugin](https://www.npmjs.com/package/chainlink-pricefeed-plugin) provides access to the [**Chainlink price feeds**](https://docs.chain.link/data-feeds/price-feeds) to get data aggregated from many data sources. It exposes the action (`get price feed`) that allows you to get the current price for ETH, BTC, HBAR, LINK, USDC, UST or DAI.
+
+  NPM: https://www.npmjs.com/package/chainlink-pricefeed-plugin
+
+  Github repository: https://github.com/henrytongv/chainlink-price-plugin-js
+
+
 
 - [Hedera T3N Plugin](https://www.npmjs.com/package/@terminal3/hedera-t3n-plugin) provides access to [Terminal 3 Network (T3N)](https://docs.terminal3.io/t3n/) to enable identity verification, authentication, and last mile-delivery or selective disclosure of private and sensitive information for AI-driven applications, ensuring compliant and auditable interactions.
 
-  Github repository: [https://github.com/Terminal-3/hedera-t3n-plugin](https://github.com/Terminal-3/hedera-t3n-plugin)
+  NPM: https://www.npmjs.com/package/@terminal3/hedera-t3n-plugin
+
+  Github repository: https://github.com/Terminal-3/hedera-t3n-plugin
+
 
 ## Plugin Architecture
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -16,6 +16,10 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Github repository: https://github.com/buidler-labs/hak-memejob-plugin
 
+  Version: @buidlerlabs/hak-memejob-plugin@1.0.2
+
+  Status: Not validated by HAK team, v3-compatible release  
+
 
 - [Bonzo Plugin](https://www.npmjs.com/package/@bonzofinancelabs/hak-bonzo-plugin) is a unified SDK to the [**Bonzo**](https://bonzo.finance) protocol, exposing the core actions (`deposit`, `withdraw`, `repay`, `borrow`) for decentralised lending and borrowing on Hedera:
 
@@ -23,14 +27,31 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Github repository: https://github.com/Bonzo-Labs/bonzoPlugin
 
+  Version: @bonzofinancelabs/hak-bonzo-plugin@1.0.1
 
-- [SaucerSwap Plugin](https://www.npmjs.com/package/saucer-swap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`get_swap_quote_v2_tool`, `swap_v2_tool`) for executing swaps and obtaining swap quotes.
+  Status: Not validated by HAK team, v3-compatible release  
+
+
+- [SaucerSwap Labs Plugin](https://www.npmjs.com/package/saucer-swap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`get_swap_quote_v2_tool`, `swap_v2_tool`) for executing swaps and obtaining swap quotes.
 
   NPM: https://www.npmjs.com/package/saucer-swap-plugin
 
   Github repository: https://github.com/saucerswaplabs/hedera-agent-kit-saucer-swap-plugin
 
-  Tested/endorsed version: saucer-swap-plugin@0.2.0 (migrated to HAK V4)
+  Version: saucer-swap-plugin@0.2.0
+
+  Status: Validated by HAK team, v4-compatible release
+
+
+- [HAK SaucerSwap Plugin](https://www.npmjs.com/package/hak-saucerswap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`saucerswap_get_swap_quote`, `saucerswap_swap_tokens`, `saucerswap_get_pools`, `saucerswap_add_liquidity`, `saucerswap_remove_liquidity`, `saucerswap_get_farms`) for swaps, liquidity, and farming insights:
+
+  NPM: https://www.npmjs.com/package/hak-saucerswap-plugin
+
+  Github repository: https://github.com/jmgomezl/hak-saucerswap-plugin
+
+  Version: hak-saucerswap-plugin@2.1.0
+
+  Status: Validated by HAK team, v4-compatible release
 
 
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
@@ -39,6 +60,9 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Github repository: https://github.com/jmgomezl/hak-pyth-plugin
 
+  Version: hak-pyth-plugin@0.2.0
+
+  Status: Validated by HAK team, v4-compatible release
 
 
 - [CoinCap Plugin](https://www.npmjs.com/package/coincap-hedera-plugin) provides access to the [**CoinCap API service**](https://www.coincap.io) to access cryptocurrency market data. It exposes the action (`get HBAR price in USD`) to get the current price of HBAR in USD currency, by using it you can ask your agent to get your current HBAR balance expressed in USD.
@@ -47,6 +71,9 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Github repository: https://github.com/henrytongv/coincap-hedera-plugin
 
+  Version: coincap-hedera-plugin@1.0.5
+
+  Status: Validated by HAK team, v4-compatible release  
 
 
 - [Chainlink price feed Plugin](https://www.npmjs.com/package/chainlink-pricefeed-plugin) provides access to the [**Chainlink price feeds**](https://docs.chain.link/data-feeds/price-feeds) to get data aggregated from many data sources. It exposes the action (`get price feed`) that allows you to get the current price for ETH, BTC, HBAR, LINK, USDC, UST or DAI.
@@ -55,6 +82,9 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Github repository: https://github.com/henrytongv/chainlink-price-plugin-js
 
+  Version: chainlink-pricefeed-plugin@1.0.5
+
+  Status: Validated by HAK team, v4-compatible release  
 
 
 - [Hedera T3N Plugin](https://www.npmjs.com/package/@terminal3/hedera-t3n-plugin) provides access to [Terminal 3 Network (T3N)](https://docs.terminal3.io/t3n/) to enable identity verification, authentication, and last mile-delivery or selective disclosure of private and sensitive information for AI-driven applications, ensuring compliant and auditable interactions.
@@ -63,6 +93,9 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Github repository: https://github.com/Terminal-3/hedera-t3n-plugin
 
+  Version: @terminal3/hedera-t3n-plugin@3.0.0
+
+  Status: Not validated by HAK team, v3-compatible release
 
 ## Plugin Architecture
 
@@ -431,8 +464,9 @@ Once you have a repository, published npm package, and a README with a descripti
 
 ```Bonzo Plugin is a unified SDK to the Bonzo protocol, exposing the core actions (deposit, withdraw, repay, borrow) for decentralised lending and borrowing on Hedera:
 NPM: https://www.npmjs.com/package/@bonzofinancelabs/hak-bonzo-plugin
-Source: https://www.npmjs.com/package/@bonzofinancelabs/hak-bonzo-plugin
-✅ Tested/endorsed version: bonzofinancelabs/hak-bonzo-plugin==1.0.1
+Github repository: https://github.com/Bonzo-Labs/bonzoPlugin
+Version: @bonzofinancelabs/hak-bonzo-plugin@1.0.1
+Status: Not validated by HAK team, v3-compatible release 
 ```
 
 Feel free to also [reach out to the Hedera Agent Kit maintainers on Discord](https://hedera.com/discord) or another channel so we can test out your plugin, include it in our docs, and let our community know thorough marketing and community channels.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -16,9 +16,9 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Github repository: https://github.com/buidler-labs/hak-memejob-plugin
 
-  Version: @buidlerlabs/hak-memejob-plugin@1.0.2
+  Version: @buidlerlabs/hak-memejob-plugin@1.1.0
 
-  Status: Not validated by HAK team, v3-compatible release  
+  Status: Validated by HAK team, v4-compatible release 
 
 
 - [Bonzo Plugin](https://www.npmjs.com/package/@bonzofinancelabs/hak-bonzo-plugin) is a unified SDK to the [**Bonzo**](https://bonzo.finance) protocol, exposing the core actions (`deposit`, `withdraw`, `repay`, `borrow`) for decentralised lending and borrowing on Hedera:


### PR DESCRIPTION
- Updated saucer-swap-plugin@0.2.0 (migrated to HAK v4)
- Updated hak-saucerswap-plugin@2.1.0 (migrated to HAK v4)
- Updated hak-pyth-plugin@0.2.0 (migrated to HAK v4)
- Updated coincap-hedera-plugin@1.0.5 (migrated to HAK v4)
- Updated chainlink-pricefeed-plugin@1.0.5 (migrated to HAK v4)
- Updated @buidlerlabs/hak-memejob-plugin@1.1.0 (migrated to HAK v4)
- Applied consistent formatting to all plugins in README.md and docs/PLUGINS.md