### PR TITLE
docs: update SaucerSwap plugin to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ The Hedera Agent Kit is extensible with third party plugins by other projects. S
 
   Github repository: [https://github.com/Bonzo-Labs/bonzoPlugin](https://github.com/Bonzo-Labs/bonzoPlugin)
 
-- [SaucerSwap Plugin](https://www.npmjs.com/package/hak-saucerswap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`saucerswap_get_swap_quote`, `saucerswap_swap_tokens`, `saucerswap_get_pools`, `saucerswap_add_liquidity`, `saucerswap_remove_liquidity`, `saucerswap_get_farms`) for swaps, liquidity, and farming insights:
+- [SaucerSwap Plugin](https://www.npmjs.com/package/hak-saucerswap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`saucerswap_get_swap_quote`, `saucerswap_swap_tokens`, `saucerswap_get_pools`, `saucerswap_add_liquidity`, `saucerswap_remove_liquidity`, `saucerswap_get_farms`) for swaps, liquidity, and farming insights. Supports native API key authentication, built-in mainnet/testnet contract address defaults, and full `BaseTool` + `handleTransaction` lifecycle compatibility:
 
   NPM: https://www.npmjs.com/package/hak-saucerswap-plugin
   Source: https://github.com/jmgomezl/hak-saucerswap-plugin
-  Tested/endorsed version: hak-saucerswap-plugin@1.0.1
+  Tested/endorsed version: hak-saucerswap-plugin@2.1.0
 
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -9,11 +9,11 @@ The Hedera services built into this agent toolkit are also implemented as plugin
 
 See this list of available third party plugins for the Hedera Agent Kit Python SDK in the [README](../README.md) and in the [Hedera Docs](https://docs.hedera.com/hedera/open-source-solutions/ai-studio-on-hedera/hedera-ai-agent-kit/hedera-agent-kit-js/plugins).
 
-- [SaucerSwap Plugin](https://www.npmjs.com/package/hak-saucerswap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`saucerswap_get_swap_quote`, `saucerswap_swap_tokens`, `saucerswap_get_pools`, `saucerswap_add_liquidity`, `saucerswap_remove_liquidity`, `saucerswap_get_farms`) for swaps, liquidity, and farming insights:
+- [SaucerSwap Plugin](https://www.npmjs.com/package/hak-saucerswap-plugin) provides a streamlined interface to the [**SaucerSwap**](https://saucerswap.finance) DEX, exposing the core actions (`saucerswap_get_swap_quote`, `saucerswap_swap_tokens`, `saucerswap_get_pools`, `saucerswap_add_liquidity`, `saucerswap_remove_liquidity`, `saucerswap_get_farms`) for swaps, liquidity, and farming insights. Supports native API key authentication, built-in mainnet/testnet contract address defaults, and full `BaseTool` + `handleTransaction` lifecycle compatibility:
 
   NPM: https://www.npmjs.com/package/hak-saucerswap-plugin
   Source: https://github.com/jmgomezl/hak-saucerswap-plugin
-  Tested/endorsed version: hak-saucerswap-plugin@1.0.1
+  Tested/endorsed version: hak-saucerswap-plugin@2.1.0
 
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
 


### PR DESCRIPTION
## Summary

Updates the tested/endorsed version of the SaucerSwap plugin in both `README.md` and `docs/PLUGINS.md` from `1.0.1` to `2.1.0`, and expands the description to reflect the changes introduced in v2.x.

## What changed in v2.x

- **SDK migration** — updated to `@hiero-ledger/sdk` (v2.82.0) and `@hashgraph/hedera-agent-kit` (v4) scoped packages
- **Native API key support** — `SAUCERSWAP_API_KEY` env var forwarded as `x-api-key` header on all requests; no workarounds needed
- **Network address defaults** — ships `SAUCERSWAP_MAINNET` and `SAUCERSWAP_TESTNET` constants with official router, WHBAR, SAUCE, and xSAUCE addresses; users can set `network: "mainnet"` instead of looking up contract IDs manually
- **BaseTool + handleTransaction** — all transaction tools (swap, add/remove liquidity) refactored to the v4 `BaseTool` lifecycle with `coreAction` / `secondaryAction` split
- **Full documentation** — `docs/TOOLS.md` (HAK-style per-tool reference), `docs/CONFIGURATION.md` (full settings table with env vars), `docs/EXAMPLES.md`
- **Unit tests** — 25 tests covering error paths and happy-path payload shape for all tool families

## Files changed

| File | Change |
|------|--------|
| `README.md` | Version `1.0.1` → `2.1.0`, expanded description |
| `docs/PLUGINS.md` | Version `1.0.1` → `2.1.0`, expanded description |

Signed-off-by: Juanma Gomez <juanmag.lpez@gmail.com>