### PR TITLE
docs: bump hak-pyth-plugin endorsed version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The Hedera Agent Kit is extensible with third party plugins by other projects. S
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
 
   Github repository: [https://github.com/jmgomezl/hak-pyth-plugin](https://github.com/jmgomezl/hak-pyth-plugin).
-  Tested/endorsed version of plugin: hak-pyth-plugin@0.1.1
+  Tested/endorsed version of plugin: hak-pyth-plugin@0.2.0
 
 - [CoinCap Plugin](https://www.npmjs.com/package/coincap-hedera-plugin) provides access to the [**CoinCap API service**](https://www.coincap.io) to access cryptocurrency market data. It exposes the action (`get HBAR price in USD`) to get the current price of HBAR in USD currency, by using it you can ask your agent to get your current HBAR balance expressed in USD.
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -18,7 +18,7 @@ See this list of available third party plugins for the Hedera Agent Kit Python S
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
 
   Github repository: [https://github.com/jmgomezl/hak-pyth-plugin](https://github.com/jmgomezl/hak-pyth-plugin).
-  Tested/endorsed version of plugin: hak-pyth-plugin@0.1.1
+  Tested/endorsed version of plugin: hak-pyth-plugin@0.2.0
 
 - [Hedera T3N Plugin](https://www.npmjs.com/package/@terminal3/hedera-t3n-plugin) provides access to [Terminal 3 Network (T3N)](https://docs.terminal3.io/t3n/) to enable identity verification, authentication, and last mile-delivery or selective disclosure of private and sensitive information for AI-driven applications, ensuring compliant and auditable interactions.
 


### PR DESCRIPTION
## Summary

- Updates the tested/endorsed version of `hak-pyth-plugin` from `0.1.1` → `0.2.0` in `README.md` and `docs/PLUGINS.md`

## What changed in hak-pyth-plugin@0.2.0

This release addresses all feedback from Issue [#1](https://github.com/jmgomezl/hak-pyth-plugin/issues/1) raised by @skurzyp-blockydevs during the docs inclusion review:

- **Config pattern fixed** — plugin config now accepted via `context.pyth` (the recommended HAK pattern)
- **README updated** — agentic LLM prompt examples, token context window warning, corrected configuration snippet, links to Hedera AI Agent Kit docs and Pyth Hermes API docs
- **`.env.example`** added with all supported environment variables
- **`examples/` directory** added with fully-wired LangChain and Vercel AI agent scripts
- **Test coverage** expanded from 9 → 31 tests (added tool-level tests, `resolvePythConfig` tests, `normalizePriceUpdate` tests)

## DCO

Signed-off-by: Juanma Gomez <juanmag.lpez@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)