### PR TITLE
docs(plugins): add hak-stader-plugin v1.0.0 — Stader liquid staking on Hedera

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -107,6 +107,16 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Status: Validated by HAK team, v4-compatible release
 
+- [HAK Stader Plugin](https://www.npmjs.com/package/hak-stader-plugin) integrates [**Stader**](https://www.staderlabs.com/hedera/) liquid staking on Hedera, exposing the core actions (`stader_stake_hbar`, `stader_approve_hbarx`, `stader_unstake_hbar`, `stader_claim_withdrawal`, `stader_get_pending_withdrawals`, `stader_get_hbarx_balance`, `stader_get_exchange_rate`, `stader_get_staking_info`) for staking HBAR to receive HBARX (a yield-bearing liquid staking token usable in DeFi):
+
+  NPM: https://www.npmjs.com/package/hak-stader-plugin
+
+  Github repository: https://github.com/hedera-dev/hak-stader-plugin
+
+  Version: hak-stader-plugin@1.0.1
+
+  Status: Not validated by HAK team, v4-compatible release
+
 ## Plugin Architecture
 
 The tools are now organized into plugins, each containing a set functionality related to the Hedera service or project they are created for.


### PR DESCRIPTION
## Summary

Adds [`hak-stader-plugin@1.0.0`](https://www.npmjs.com/package/hak-stader-plugin) to the third-party plugins list in `docs/PLUGINS.md` and `README.md`.

This plugin integrates [Stader](https://www.staderlabs.com/hedera/) liquid staking on Hedera, allowing agents to stake HBAR and receive **HBARX** — a yield-bearing liquid staking token that remains transferable and usable in DeFi while earning staking rewards.

## Tools exposed

| Tool | Type | Description |
|------|------|-------------|
| `stader_stake_hbar` | Transaction | Stake HBAR, receive HBARX |
| `stader_approve_hbarx` | Transaction | Grant HTS allowance before unstaking |
| `stader_unstake_hbar` | Transaction | Initiate unstake (1-day unbonding period) |
| `stader_claim_withdrawal` | Transaction | Claim HBAR after unbonding |
| `stader_get_pending_withdrawals` | Query | List pending withdrawal requests with claimable status |
| `stader_get_hbarx_balance` | Query | Get HBARX token balance for an account |
| `stader_get_exchange_rate` | Query | Get HBARX/HBAR rate computed via Hedera Mirror Node |
| `stader_get_staking_info` | Query | Protocol status, unbonding period, contract addresses |

## Implementation notes

- Built on `BaseTool` (v4 pattern) — full hooks and policies support
- Exchange rate computed off-chain via Mirror Node (the on-chain `getExchangeRate()` is deprecated and always returns 1.0)
- Unstaking requires a prior HTS token allowance (`AccountAllowanceApproveTransaction`) — the plugin exposes a dedicated `stader_approve_hbarx` tool for this
- 50 unit tests, zero real network calls in tests (all dependencies injected via context)
- Pairs naturally with `hak-saucerswap-plugin` for a full agent-driven yield loop: stake HBAR → receive HBARX → LP on SaucerSwap → farm rewards

## Links

- NPM: https://www.npmjs.com/package/hak-stader-plugin
- GitHub: https://github.com/jmgomezl/hak-stader-plugin
- Version: `hak-stader-plugin@1.0.0`

## Checklist

- [x] Entry added to `docs/PLUGINS.md` under Available Third Party Plugins
- [x] Entry added to `README.md` under Third Party Plugins
- [x] Commit is DCO-signed (`git commit -s`)
- [x] Package published to npm at exact version referenced

> Note: the Assignee Check CI failure is expected for external contributors — maintainers assign themselves.