### PR TITLE
docs: add hak-layerzero-plugin to third-party plugins list

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -107,6 +107,16 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Status: Validated by HAK team, v4-compatible release
 
+- [HAK LayerZero Plugin](https://www.npmjs.com/package/hak-layerzero-plugin) enables AI agents to send cross-chain messages and query fees between Hedera and 150+ EVM chains (Ethereum, Arbitrum, Base, Optimism, Polygon, BNB Chain, Avalanche, and more) via [**LayerZero V2**](https://layerzero.network/), exposing tools for chain discovery (`layerzero_get_supported_chains`), fee estimation (`layerzero_get_message_fee`), message sending (`layerzero_send_message`), and delivery tracking (`layerzero_get_message_status`):
+
+  NPM: https://www.npmjs.com/package/hak-layerzero-plugin
+
+  Github repository: https://github.com/jmgomezl/hak-layerzero-plugin
+
+  Version: hak-layerzero-plugin@1.0.1
+
+  Status: Not validated by HAK team, v4-compatible release
+
 ## Plugin Architecture
 
 The tools are now organized into plugins, each containing a set functionality related to the Hedera service or project they are created for.


### PR DESCRIPTION
## Summary

- Adds **hak-layerzero-plugin@1.0.0** entry to `docs/PLUGINS.md` under Available Third Party Plugins
- Adds the same plugin to the **Third Party Plugins** section of `README.md`

The plugin enables AI agents to send cross-chain messages and query fees between Hedera and 150+ EVM chains via [LayerZero V2](https://layerzero.network/) — filling the cross-chain gap in the Hedera DeFi agent stack.

**Published package:** https://www.npmjs.com/package/hak-layerzero-plugin  
**GitHub repo:** https://github.com/jmgomezl/hak-layerzero-plugin

### Tools exposed

| Tool | Type | Description |
|---|---|---|
| `layerzero_get_supported_chains` | Query | Lists chains reachable from Hedera with their LayerZero EIDs |
| `layerzero_get_message_fee` | Query | Estimates HBAR fee via on-chain `EndpointV2.quote()` |
| `layerzero_send_message` | Transaction | Sends cross-chain message from OApp on Hedera |
| `layerzero_get_message_status` | Query | Tracks delivery status via LayerZero Scan API |

### Technical details

- TypeScript ESM + CJS dual output, HAK v4 `BaseTool` architecture
- Confirmed Hedera mainnet EndpointV2: `0x3A73033C0b1407574C76BdBAc67f126f6b4a9AA9` (EID 30316)
- 25 unit tests, all passing
- Full docs: TOOLS.md, CONFIGURATION.md, EXAMPLES.md, AGENTS.md

> **Note:** Assignee Check CI failure is expected for external contributors — maintainers assign themselves.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)