### PR TITLE
docs(plugins): add hak-axelar-plugin v1.0.0 — Axelar cross-chain bridging on Hedera

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -107,6 +107,16 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Status: Validated by HAK team, v4-compatible release
 
+- [HAK Axelar Plugin](https://www.npmjs.com/package/hak-axelar-plugin) enables AI agents to bridge [**Axelar ITS**](https://axelar.network/) tokens and send GMP cross-chain messages between Hedera and 60+ chains (Ethereum, Base, Arbitrum, Polygon, Avalanche, XRPL, and more) via the Axelar Amplifier architecture, exposing tools for chain discovery (`axelar_get_supported_chains`), fee estimation (`axelar_get_message_fee`), GMP messaging (`axelar_send_message`), ITS token bridging (`axelar_send_token`), and delivery tracking (`axelar_get_message_status`):
+
+  NPM: https://www.npmjs.com/package/hak-axelar-plugin
+
+  Github repository: https://github.com/jmgomezl/hak-axelar-plugin
+
+  Version: hak-axelar-plugin@1.0.1
+
+  Status: Not validated by HAK team, v4-compatible release
+
 ## Plugin Architecture
 
 The tools are now organized into plugins, each containing a set functionality related to the Hedera service or project they are created for.


### PR DESCRIPTION
## Summary

Adds **[hak-axelar-plugin](https://www.npmjs.com/package/hak-axelar-plugin)** to the third-party plugins list in both `README.md` and `docs/PLUGINS.md`.

### Plugin overview

`hak-axelar-plugin` enables AI agents to bridge ITS tokens and send GMP cross-chain messages between Hedera and 60+ chains via the [Axelar Amplifier](https://axelar.network/) architecture.

**Tools exposed:**
- `axelar_get_supported_chains` — list chains available via the Axelar GMP API
- `axelar_get_message_fee` — estimate relay gas cost for a destination chain
- `axelar_send_message` — send an arbitrary GMP payload to an AxelarExecutable contract on another chain (two-tx flow: GasService + Gateway)
- `axelar_send_token` — bridge a registered ITS token in a single transaction via `InterchainTokenService.interchainTransfer()`
- `axelar_get_message_status` — poll delivery status from the Axelar GMP API

**Notes:**
- Uses Hedera's Amplifier architecture (not classic gateway) — deposit-address bridging and axlUSDC are not available; only ITS-registered tokens can be bridged
- No `@axelar-network/axelarjs-sdk` dependency — direct REST calls to avoid ethers v5 / ESM conflicts
- v4-compatible: plain `Plugin` object, zod v3, `BaseTool` with `normalizeParams` / `coreAction` / `secondaryAction`

**Links:**
- NPM: https://www.npmjs.com/package/hak-axelar-plugin
- GitHub: https://github.com/jmgomezl/hak-axelar-plugin

## Checklist

- [x] Entry added to `README.md` Third Party Plugins section
- [x] Entry added to `docs/PLUGINS.md` with NPM, GitHub, version, and status fields
- [x] Commit signed off (`-s`) per DCO requirement
- [x] Single clean commit