### PR TITLE
feat: expose agent tool summaries

### DIFF
--- a/packages/core/src/shared/api.ts
+++ b/packages/core/src/shared/api.ts
@@ -3,6 +3,8 @@ import { Client } from '@hiero-ledger/sdk';
 import type { Context } from './configuration';
 import { Tool } from './tools';
 
+export type ToolSummary = Pick<Tool, 'method' | 'name' | 'description'>;
+
 class HederaAgentAPI {
   client: Client;
 
@@ -17,6 +19,10 @@ class HederaAgentAPI {
     }
     this.context = context || {};
     this.tools = tools || [];
+  }
+
+  listTools(): ToolSummary[] {
+    return this.tools.map(({ method, name, description }) => ({ method, name, description }));
   }
 
   async run(method: string, arg: unknown) {

--- a/packages/core/tests/unit/shared/api.unit.test.ts
+++ b/packages/core/tests/unit/shared/api.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { Client } from '@hiero-ledger/sdk';
+import { z } from 'zod';
+
+import HederaAgentAPI from '../../../src/shared/api';
+import type { Tool } from '../../../src/shared/tools';
+
+const client = Client.forTestnet();
+const tool: Tool = {
+  method: 'demo_tool',
+  name: 'Demo Tool',
+  description: 'A demo tool',
+  parameters: z.object({}),
+  execute: async () => ({ ok: true }),
+};
+
+describe('HederaAgentAPI', () => {
+  it('lists registered tools without exposing executable handlers', () => {
+    const api = new HederaAgentAPI(client, {}, [tool]);
+
+    expect(api.listTools()).toEqual([
+      {
+        method: 'demo_tool',
+        name: 'Demo Tool',
+        description: 'A demo tool',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a unit test covering the new summary output
Fixes #834.
## Verification
- Attempted: corepack pnpm --filter @hashgraph/hedera-agent-kit test:unit -- packages/core/tests/unit/shared/api.unit.test.ts
- Blocked locally because node_modules is missing and dependency install did not complete within the cron run.