### PR TITLE
feat: add HederaAgentKit API alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Install the core package, LangChain toolkit, your LLM provider, and the Hedera S
 npm install @hiero-ledger/sdk @hashgraph/hedera-agent-kit @hashgraph/hedera-agent-kit-langchain @langchain/openai dotenv
 ```
 
+> v4 uses `@hiero-ledger/sdk` as its Hedera SDK peer dependency. The examples do not use `@hashgraph/sdk`; import `Client` and other SDK types from `@hiero-ledger/sdk`.
+>
+> The main runtime class is available as `HederaAgentAPI` and `HederaAgentKit`. New examples still use `HederaAgentAPI`; `HederaAgentKit` is an alias for developers who look for a class that matches the package name.
+>
 > Using a different LLM? Replace `@langchain/openai` with `@langchain/anthropic`, `@langchain/groq`, or `@langchain/ollama`.
 
 ### 2 – Configure: Add Environment Variables

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -145,6 +145,10 @@ Install the core package, LangChain toolkit, your LLM provider, and the Hedera S
 npm install @hiero-ledger/sdk @hashgraph/hedera-agent-kit @hashgraph/hedera-agent-kit-langchain @langchain/openai dotenv
 ```
 
+> v4 uses `@hiero-ledger/sdk` as its Hedera SDK peer dependency. The examples do not use `@hashgraph/sdk`; import `Client` and other SDK types from `@hiero-ledger/sdk`.
+>
+> The main runtime class is available as `HederaAgentAPI` and `HederaAgentKit`. New examples still use `HederaAgentAPI`; `HederaAgentKit` is an alias for developers who look for a class that matches the package name.
+>
 > Using a different LLM? Replace `@langchain/openai` with `@langchain/anthropic`, `@langchain/groq`, or `@langchain/ollama`.
 
 ### 2 – Configure: Add Environment Variables

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@
 
 // Primary types
 export { default as HederaAgentAPI } from './shared/api';
+export { default as HederaAgentKit } from './shared/api';
 export { AgentMode } from './shared/configuration';
 export type { Configuration, Context } from './shared/configuration';
 export type { Plugin } from './shared/plugin';

--- a/packages/core/tests/unit/shared/index-exports.unit.test.ts
+++ b/packages/core/tests/unit/shared/index-exports.unit.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { HederaAgentAPI, HederaAgentKit } from '@hashgraph/hedera-agent-kit';
+
+describe('core package exports', () => {
+  it('keeps HederaAgentKit as an alias of HederaAgentAPI', () => {
+    expect(HederaAgentKit).toBe(HederaAgentAPI);
+  });
+});


### PR DESCRIPTION
## Summary
- export `HederaAgentKit` as an alias for the existing `HederaAgentAPI`
- document that v4 examples use `@hiero-ledger/sdk`
- add a unit test covering the alias

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @hashgraph/hedera-agent-kit build`
- `pnpm --filter @hashgraph/hedera-agent-kit exec vitest run tests/unit/shared/index-exports.unit.test.ts tests/unit/utils/decimals-utils.unit.test.ts`
- `pnpm --filter @hashgraph/hedera-agent-kit test:unit`
- `git diff --check`
- `gitleaks git --staged --redact --no-banner --no-color`

Refs #836.