### PR TITLE
feat: add read-only toolkit option

### DIFF
--- a/packages/core/src/shared/configuration.ts
+++ b/packages/core/src/shared/configuration.ts
@@ -31,4 +31,6 @@ export type Configuration = {
   //plugins to load - must be explicitly provided
   plugins?: Plugin[];
   context?: Context;
+  // When true, only non-mutating query tools may be registered.
+  readOnly?: boolean;
 };

--- a/packages/core/src/shared/tool-discovery.ts
+++ b/packages/core/src/shared/tool-discovery.ts
@@ -12,6 +12,9 @@ export class ToolDiscovery {
   getAllTools(context: Context, configuration?: Configuration): Tool[] {
     // Get plugin tools
     const pluginTools = this.pluginRegistry.getTools(context);
+    if (configuration?.readOnly) {
+      this.assertReadOnlyTools(pluginTools);
+    }
 
     // Merge all tools (core tools take precedence in case of name conflicts)
     const allTools: any = [];
@@ -35,6 +38,20 @@ export class ToolDiscovery {
     }
 
     return allTools;
+  }
+
+  private assertReadOnlyTools(tools: Tool[]): void {
+    const writeTools = tools.filter(tool => !this.isReadOnlyTool(tool));
+    if (writeTools.length === 0) {
+      return;
+    }
+
+    const methods = writeTools.map(tool => tool.method).join(', ');
+    throw new Error(`readOnly configuration rejects write-capable tools: ${methods}`);
+  }
+
+  private isReadOnlyTool(tool: Tool): boolean {
+    return tool.method.startsWith('get_');
   }
 
   static createFromConfiguration(configuration: Configuration): ToolDiscovery {

--- a/packages/core/tests/unit/shared/tool-discovery.unit.test.ts
+++ b/packages/core/tests/unit/shared/tool-discovery.unit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { ToolDiscovery } from '@/shared/tool-discovery';
+import type { Context } from '@/shared/configuration';
+import type { Plugin } from '@/shared/plugin';
+import type { Tool } from '@/shared/tools';
+
+const makeTool = (method: string): Tool => ({
+  method,
+  name: method,
+  description: `${method} description`,
+  parameters: z.object({}),
+  execute: async () => ({}),
+});
+
+const makePlugin = (name: string, methods: string[]): Plugin => ({
+  name,
+  tools: (_context: Context) => methods.map(makeTool),
+});
+
+describe('ToolDiscovery readOnly configuration', () => {
+  it('keeps query tools when readOnly is enabled', () => {
+    const discovery = new ToolDiscovery([
+      makePlugin('queries', ['get_account_query_tool', 'get_hbar_balance_query_tool']),
+    ]);
+
+    const tools = discovery.getAllTools({}, {readOnly: true});
+
+    expect(tools.map(tool => tool.method)).toEqual([
+      'get_account_query_tool',
+      'get_hbar_balance_query_tool',
+    ]);
+  });
+
+  it('rejects write-capable tools when readOnly is enabled', () => {
+    const discovery = new ToolDiscovery([
+      makePlugin('mixed', ['get_account_query_tool', 'transfer_hbar_tool']),
+    ]);
+
+    expect(() => discovery.getAllTools({}, {readOnly: true})).toThrow(
+      /transfer_hbar_tool/,
+    );
+  });
+
+  it('preserves existing behavior when readOnly is disabled', () => {
+    const discovery = new ToolDiscovery([
+      makePlugin('mixed', ['get_account_query_tool', 'transfer_hbar_tool']),
+    ]);
+
+    const tools = discovery.getAllTools({}, {});
+
+    expect(tools.map(tool => tool.method)).toEqual([
+      'get_account_query_tool',
+      'transfer_hbar_tool',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `readOnly` option to core configuration.
- Enforce read-only tool discovery by rejecting non-query tools when `readOnly` is enabled.
- Add unit coverage for read-only, mixed-tool rejection, and existing default behavior.

## Approach
The guard is intentionally fail-closed: if a plugin returns any non-`get_` tool while `readOnly` is enabled, tool discovery throws with the unsafe method names instead of silently exposing write-capable actions to an agent.

## Validation
- `pnpm exec vitest run tests/unit/shared/tool-discovery.unit.test.ts`

Note: the package `test:unit` script also ran the broader unit suite locally and surfaced an existing package-entry resolution issue in `tests/unit/utils/decimals-utils.unit.test.ts`; the new `tool-discovery` unit test passed in that run and passes directly with the command above.

Closes #861

Disclosure: this PR was prepared with AI assistance through Codex. I reviewed the diff and validation before submitting it under my GitHub account.