### PR TITLE
docs(plugins): add hak-github-pay-plugin v2.3.0 — pay GitHub contributors in HBAR on merge

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -107,6 +107,16 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Status: Validated by HAK team, v4-compatible release
 
+- [HAK GitHub Pay Plugin](https://www.npmjs.com/package/hak-github-pay-plugin) pays open-source contributors in HBAR when their GitHub pull request is merged, with payment policy, the GitHub-to-Hedera identity registry, receipts, and software-release provenance all sealed immutably on Hedera Consensus Service. It exposes the core actions (`github_pay_register_contributor`, `github_pay_set_payment_policy`, `github_pay_set_payment_cap`, `github_pay_pay_on_merge`, `github_pay_query_contributor_payments`, `github_pay_seal_release_provenance`, `github_pay_query_team_summary`) for registering contributors, setting label-to-HBAR policies and spending caps, paying on merge (HMAC-validated webhook, idempotent, cap-enforced), querying payment history as CSV, and sealing SHA-256 release provenance:
+
+  NPM: https://www.npmjs.com/package/hak-github-pay-plugin
+
+  Github repository: https://github.com/jmgomezl/hak-plugin-github-pay
+
+  Version: hak-github-pay-plugin@2.3.0
+
+  Status: Not validated by HAK team, v4-compatible release
+
 ## Plugin Architecture
 
 The tools are now organized into plugins, each containing a set functionality related to the Hedera service or project they are created for.


### PR DESCRIPTION
Adds **hak-github-pay-plugin** to the third-party plugins list in `docs/PLUGINS.md` and `README.md`.

### What it does
A HAK v4 plugin that turns the GitHub merge button into a payment rail: when a pull request is merged, an AI agent pays the contributor in HBAR. There is no database — payment policy, the GitHub→Hedera identity registry, every receipt, and software-release provenance all live immutably on four Hedera Consensus Service topics, verifiable on Hashscan.

### Tools (7)
- `github_pay_register_contributor` — map a GitHub handle → Hedera account on a public IDENTITIES topic (a reusable public good)
- `github_pay_set_payment_policy` — `label → HBAR` payout rules
- `github_pay_set_payment_cap` — monthly + per-contributor spending ceilings
- `github_pay_pay_on_merge` — HMAC-validated, idempotent, cap-enforced payout + sealed receipt
- `github_pay_query_contributor_payments` — payment history as CSV
- `github_pay_seal_release_provenance` — SHA-256 release-asset provenance (NIST SSDF)
- `github_pay_query_team_summary` — per-contributor aggregate CSV

### Links
- NPM: https://www.npmjs.com/package/hak-github-pay-plugin
- Repo: https://github.com/jmgomezl/hak-plugin-github-pay
- Live demo: https://github-pay.aivylabs.xyz

Built on Hedera Agent Kit v4 (`BaseTool` + plain-object plugin pattern, config resolved from the HAK `Context`). Commits are DCO signed-off.