### PR TITLE
feat(core): add minimal DEX swap_tokens_tool (#7)

### DIFF
--- a/docs/HEDERAPLUGINS.md
+++ b/docs/HEDERAPLUGINS.md
@@ -18,6 +18,7 @@ The tools are organized into plugins, each containing related functionality:
 * **Core Token Plugin**: Tools for Hedera Token Service (HTS) operations
 * **Core Token Query Plugin**: Tools for querying Hedera Token Service related data
 * **Core EVM Plugin**: Tools for interacting with EVM smart contracts on Hedera (ERC-20 and ERC-721)
+* **Core DEX Plugin**: Tools for swapping tokens on Hedera DEXs (Uniswap V2 style routers)
 * **Core EVM Query Plugin**: Tools for querying smart contract-related data on Hedera
 * **Core Misc Query Plugin**: Tools for fetching miscellaneous information from Hedera Mirror Node
 * **Core Transaction Query Plugin**: Tools for handling Hedera transaction–related queries
@@ -132,6 +133,16 @@ This plugin provides tools for interacting with EVM smart contracts on Hedera, i
 | [`CREATE_ERC721_TOOL`](./HEDERATOOLS.md#create_erc721_tool)           | Deploys a new ERC-721 token via the BaseERC721Factory | [View Parameters & Examples](./HEDERATOOLS.md#create_erc721_tool)        |
 | [`MINT_ERC721_TOOL`](./HEDERATOOLS.md#mint_erc721_tool)               | Mints a new ERC-721 token                             | [View Parameters & Examples](./HEDERATOOLS.md#mint_erc721_tool)          |
 | [`TRANSFER_ERC721_TOOL`](./HEDERATOOLS.md#transfer_erc721_tool)       | Transfers an ERC-721 token                            | [View Parameters & Examples](./HEDERATOOLS.md#transfer_erc721_tool)      |
+
+---
+
+### Core DEX Plugin Tools (`core-dex-plugin`)
+
+This plugin provides tools for swapping tokens on Hedera DEXs via Uniswap V2 style routers (e.g. SaucerSwap).
+
+| Tool Name                                                | Description                                    | Details                                                         |
+|----------------------------------------------------------|------------------------------------------------|-----------------------------------------------------------------|
+| [`SWAP_TOKENS_TOOL`](./HEDERATOOLS.md#swap_tokens_tool)  | Swaps an exact amount of one token for another | [View Parameters & Examples](./HEDERATOOLS.md#swap_tokens_tool) |
 
 ---
 
@@ -252,6 +263,7 @@ import {
   coreTokenPlugin,
   coreTokenQueryPlugin,
   coreEVMPlugin,
+  coreDexPlugin,
   coreEVMQueryPlugin,
   coreMiscQueriesPlugin,
   coreTransactionQueryPlugin,
@@ -283,6 +295,7 @@ const hederaAgentToolkit = new HederaLangchainToolkit({
       coreTokenPlugin,
       coreTokenQueryPlugin,
       coreEVMPlugin,
+      coreDexPlugin,
       coreEVMQueryPlugin,
       coreMiscQueriesPlugin,
       coreTransactionQueryPlugin,

--- a/docs/HEDERATOOLS.md
+++ b/docs/HEDERATOOLS.md
@@ -55,6 +55,8 @@ For a high-level overview of available plugins, see [HEDERAPLUGINS.md](./HEDERAP
     - [CREATE_ERC721_TOOL](#create_erc721_tool)
     - [MINT_ERC721_TOOL](#mint_erc721_tool)
     - [TRANSFER_ERC721_TOOL](#transfer_erc721_tool)
+- [DEX Tools](#dex-tools)
+    - [SWAP_TOKENS_TOOL](#swap_tokens_tool)
 - [EVM Query Tools](#evm-query-tools)
     - [GET_CONTRACT_INFO_QUERY_TOOL](#get_contract_info_query_tool)
 - [Transaction Query Tools](#transaction-query-tools)
@@ -1169,6 +1171,43 @@ Send ERC721 0.0.12345 token ID 5 from 0x123... to 0x456...
 
 ```
 Schedule transfer ERC721 token 1 from contract 0.0.5678 from 0.0.1234 to 0x1234567890123456789012345678901234567890. Make it expire 01.02.2026 and wait for its expiration time with executing it.
+```
+
+---
+
+## DEX Tools
+
+### SWAP_TOKENS_TOOL
+
+**Supports Hooks & Policies**: ✅ Yes
+
+Swaps an exact amount of one token for another on a Hedera DEX by calling a Uniswap V2 style router's `swapExactTokensForTokens`. Works with any compatible router (e.g. SaucerSwap). Supports scheduled transactions.
+
+> **Allowance required:** the input token must already have an allowance granted to the router contract. For HTS tokens, use [`APPROVE_TOKEN_ALLOWANCE_TOOL`](#approve_token_allowance_tool) first.
+
+#### Parameters
+
+| Parameter          | Type       | Required | Default      | Description                                                                       |
+|--------------------|------------|----------|--------------|-----------------------------------------------------------------------------------|
+| `routerContractId` | `string`   | ✅        | —            | The DEX router contract (EVM address or Hedera ID).                               |
+| `path`             | `string[]` | ✅        | —            | Ordered swap route, input token to output token (e.g. `["0.0.111", "0.0.222"]`).  |
+| `amountIn`         | `string`   | ✅        | —            | Exact input amount, in the token's smallest unit (integer string).               |
+| `amountOutMin`     | `string`   | ✅        | —            | Minimum acceptable output, in the output token's smallest unit. Slippage floor.  |
+| `recipientAddress` | `string`   | ❌        | operator     | Address that receives the output tokens (EVM or Hedera ID).                       |
+| `deadlineSeconds`  | `number`   | ❌        | now + 20 min | Unix timestamp after which the swap is invalid.                                   |
+| `gas`              | `number`   | ❌        | `1000000`    | Gas limit for the router call.                                                    |
+
+#### Example Prompts
+
+```
+Swap 100000000 base units of token 0.0.111 for at least 95000000 of token 0.0.222 using router 0.0.12345
+Swap 5000000 of 0.0.111 for 0.0.222 via router 0.0.12345, minimum out 4900000
+```
+
+#### Example (Scheduled)
+
+```
+Schedule a swap of 100000000 of token 0.0.111 for at least 95000000 of 0.0.222 on router 0.0.12345. Make it expire 01.02.2026 and wait for its expiration time with executing it.
 ```
 
 ---

--- a/packages/core/src/plugins/core-dex-plugin/index.ts
+++ b/packages/core/src/plugins/core-dex-plugin/index.ts
@@ -1,0 +1,19 @@
+import { Plugin } from '@/shared/plugin';
+import { Context } from '@/shared/configuration';
+import swapTokensTool, { SWAP_TOKENS_TOOL } from './tools/swap-tokens';
+
+export const coreDexPlugin: Plugin = {
+  name: 'core-dex-plugin',
+  version: '1.0.0',
+  description: 'A plugin for swapping tokens on Hedera DEXs',
+  tools: (context: Context) => {
+    return [swapTokensTool(context)];
+  },
+};
+
+export { swapTokensTool, SWAP_TOKENS_TOOL };
+
+// Export tool names as an object for destructuring
+export const coreDexPluginToolNames = {
+  SWAP_TOKENS_TOOL,
+} as const;

--- a/packages/core/src/plugins/core-dex-plugin/tools/swap-tokens.ts
+++ b/packages/core/src/plugins/core-dex-plugin/tools/swap-tokens.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod';
+import { AgentMode, type Context } from '@/shared/configuration';
+import { BaseTool } from '@/shared/tools';
+import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
+import { Client, Status } from '@hiero-ledger/sdk';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
+import { swapExactTokensForTokensParameters } from '@/shared/parameter-schemas/dex.zod';
+import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
+import { PromptGenerator } from '@/shared/utils/prompt-generator';
+import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
+import {
+  DEX_SWAP_EXACT_TOKENS_FUNCTION_ABI,
+  DEX_SWAP_EXACT_TOKENS_FUNCTION_NAME,
+} from '@/shared/constants/contracts';
+import { transactionToolOutputParser } from '@/shared/utils/default-tool-output-parsing';
+import { assertEcdsaOperator } from '@/plugins/core-evm-plugin/utils/operator-key';
+
+const swapTokensPrompt = (context: Context = {}) => {
+  const contextSnippet = PromptGenerator.getContextSnippet(context);
+  const usageInstructions = PromptGenerator.getParameterUsageInstructions();
+
+  return `
+${contextSnippet}
+
+This tool swaps an exact amount of one token for another on a Hedera DEX by calling the router's swapExactTokensForTokens function. It works with any Uniswap V2 style router (e.g. SaucerSwap).
+
+Important: the input token must already have an allowance granted to the router contract before swapping. Use the approve_token_allowance_tool first for HTS tokens.
+
+Parameters:
+- routerContractId (str, required): The DEX router contract. Can be a Hedera id (e.g. "0.0.12345") or an EVM address.
+- path (string[], required): Ordered swap route as token addresses, from input token to output token (e.g. ["0.0.111", "0.0.222"]). Each entry may be a Hedera id or an EVM address.
+- amountIn (str, required): Exact amount of the input token, in its smallest unit (base units), as an integer string.
+- amountOutMin (str, required): Minimum acceptable output amount, in the output token's smallest unit. Acts as the slippage floor.
+- recipientAddress (str, optional): Address that receives the output tokens. Defaults to the operator/connected account.
+- deadlineSeconds (number, optional): Unix timestamp after which the swap is invalid. Defaults to 20 minutes from now.
+- gas (number, optional): Gas limit for the router call. Defaults to 1,000,000.
+- ${PromptGenerator.getScheduledTransactionParamsDescription(context)}
+
+${usageInstructions}
+
+Example: "Swap 100000000 base units of token 0.0.111 for at least 95000000 base units of token 0.0.222 using router 0.0.12345" performs a swap along the [0.0.111, 0.0.222] route.
+`;
+};
+
+const postProcess = (response: RawTransactionResponse) =>
+  response?.scheduleId
+    ? `Scheduled token swap successfully.
+Transaction ID: ${response.transactionId}
+Schedule ID: ${response.scheduleId.toString()}`
+    : `Token swap submitted successfully.
+Transaction ID: ${response.transactionId}`;
+
+export const SWAP_TOKENS_TOOL = 'swap_tokens_tool';
+
+export class SwapTokensTool extends BaseTool {
+  method = SWAP_TOKENS_TOOL;
+  name = 'Swap Tokens';
+  description: string;
+  parameters: ReturnType<typeof swapExactTokensForTokensParameters>;
+  outputParser = transactionToolOutputParser;
+
+  constructor(context: Context) {
+    super();
+    this.description = swapTokensPrompt(context);
+    this.parameters = swapExactTokensForTokensParameters(context);
+  }
+
+  async normalizeParams(
+    params: z.infer<ReturnType<typeof swapExactTokensForTokensParameters>>,
+    context: Context,
+    client: Client,
+  ) {
+    assertEcdsaOperator(client);
+    const mirrorNode = getMirrornodeService(context.mirrornodeService, client.ledgerId!);
+    return await HederaParameterNormaliser.normaliseSwapExactTokensForTokensParams(
+      params,
+      DEX_SWAP_EXACT_TOKENS_FUNCTION_ABI,
+      DEX_SWAP_EXACT_TOKENS_FUNCTION_NAME,
+      context,
+      mirrorNode,
+      client,
+    );
+  }
+
+  async coreAction(normalisedParams: any, _context: Context, _client: Client) {
+    return HederaBuilder.executeTransaction(normalisedParams);
+  }
+
+  async secondaryAction(transaction: any, client: Client, context: Context) {
+    if (context.mode === AgentMode.RETURN_BYTES) {
+      return await handleTransaction(transaction, client, context);
+    }
+    return await handleTransaction(transaction, client, context, postProcess);
+  }
+
+  async handleError(error: unknown, _context: Context): Promise<any> {
+    const desc = 'Failed to swap tokens';
+    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
+    console.error(`[${SWAP_TOKENS_TOOL}]`, message);
+    return { raw: { status: Status.InvalidTransaction, error: message }, humanMessage: message };
+  }
+}
+
+const tool = (context: Context): BaseTool => new SwapTokensTool(context);
+export default tool;

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -9,6 +9,7 @@ import { coreAccountPlugin } from './core-account-plugin';
 import { coreTokenPlugin } from './core-token-plugin';
 import { coreConsensusPlugin } from './core-consensus-plugin';
 import { coreEVMPlugin } from './core-evm-plugin';
+import { coreDexPlugin } from './core-dex-plugin';
 
 // Query plugins
 import { coreAccountQueryPlugin } from './core-account-query-plugin';
@@ -39,6 +40,7 @@ export const allCorePlugins: Plugin[] = [
   coreTokenPlugin,
   coreConsensusPlugin,
   coreEVMPlugin,
+  coreDexPlugin,
   coreAccountQueryPlugin,
   coreTokenQueryPlugin,
   coreConsensusQueryPlugin,
@@ -52,6 +54,7 @@ export * from './core-account-plugin';
 export * from './core-token-plugin';
 export * from './core-consensus-plugin';
 export * from './core-evm-plugin';
+export * from './core-dex-plugin';
 export * from './core-account-query-plugin';
 export * from './core-token-query-plugin';
 export * from './core-consensus-query-plugin';

--- a/packages/core/src/shared/constants/contracts.ts
+++ b/packages/core/src/shared/constants/contracts.ts
@@ -41,6 +41,12 @@ export const ERC721_TRANSFER_FUNCTION_ABI = [
 export const ERC721_MINT_FUNCTION_NAME = 'safeMint';
 export const ERC721_MINT_FUNCTION_ABI = ['function safeMint(address to) external returns (bool)'];
 
+// Uniswap V2 style DEX router swap (SaucerSwap, Pangolin, etc. expose this signature)
+export const DEX_SWAP_EXACT_TOKENS_FUNCTION_NAME = 'swapExactTokensForTokens';
+export const DEX_SWAP_EXACT_TOKENS_FUNCTION_ABI = [
+  'function swapExactTokensForTokens(uint256 amountIn, uint256 amountOutMin, address[] path, address to, uint256 deadline) external returns (uint256[] memory amounts)',
+];
+
 /**
  * Get the ERC20 factory contract address for the specified network
  * @param ledgerId - The Hedera network ledger ID

--- a/packages/core/src/shared/hedera-utils/hedera-parameter-normaliser.ts
+++ b/packages/core/src/shared/hedera-utils/hedera-parameter-normaliser.ts
@@ -92,6 +92,7 @@ import {
   transferERC20Parameters,
   transferERC721Parameters,
 } from '@/shared/parameter-schemas/evm.zod';
+import { swapExactTokensForTokensParameters } from '@/shared/parameter-schemas/dex.zod';
 import {
   normalisedTransactionRecordQueryParameters,
   transactionRecordQueryParameters,
@@ -100,6 +101,9 @@ import {
   optionalScheduledTransactionParams,
   optionalScheduledTransactionParamsNormalised,
 } from '@/shared/parameter-schemas/common.zod';
+
+// Default validity window for a DEX swap when no deadline is supplied (20 minutes).
+const DEFAULT_SWAP_DEADLINE_SECONDS = 20 * 60;
 
 export default class HederaParameterNormaliser {
   static parseParamsWithSchema(
@@ -1115,6 +1119,66 @@ export default class HederaParameterNormaliser {
       contractId,
       functionParameters,
       gas: 100_000,
+      schedulingParams,
+    };
+  }
+
+  static async normaliseSwapExactTokensForTokensParams(
+    params: z.infer<ReturnType<typeof swapExactTokensForTokensParameters>>,
+    swapFunctionAbi: string[],
+    swapFunctionName: string,
+    context: Context,
+    mirrorNode: IHederaMirrornodeService,
+    client: Client,
+  ): Promise<z.infer<ReturnType<typeof evmContractCallParamsNormalised>>> {
+    const parsedParams: z.infer<ReturnType<typeof swapExactTokensForTokensParameters>> =
+      this.parseParamsWithSchema(params, swapExactTokensForTokensParameters, context);
+
+    const contractId = await HederaParameterNormaliser.getHederaAccountId(
+      parsedParams.routerContractId,
+      mirrorNode,
+    );
+
+    // Resolve every hop in the route to an EVM address (preserving order).
+    const path = await Promise.all(
+      parsedParams.path.map((token) => AccountResolver.getHederaEVMAddress(token, mirrorNode)),
+    );
+
+    // Recipient defaults to the operator/connected account when omitted.
+    const resolvedRecipient = AccountResolver.resolveAccount(
+      parsedParams.recipientAddress,
+      context,
+      client,
+    );
+    const recipientAddress = await AccountResolver.getHederaEVMAddress(
+      resolvedRecipient,
+      mirrorNode,
+    );
+
+    const deadline =
+      parsedParams.deadlineSeconds ?? Math.floor(Date.now() / 1000) + DEFAULT_SWAP_DEADLINE_SECONDS;
+
+    const iface = new ethers.Interface(swapFunctionAbi);
+    const encodedData = iface.encodeFunctionData(swapFunctionName, [
+      BigInt(parsedParams.amountIn),
+      BigInt(parsedParams.amountOutMin),
+      path,
+      recipientAddress,
+      deadline,
+    ]);
+
+    const functionParameters = ethers.getBytes(encodedData);
+
+    // Normalize scheduling parameters (if present and isScheduled = true)
+    const schedulingParams = parsedParams?.schedulingParams?.isScheduled
+      ? (await this.normaliseScheduledTransactionParams(parsedParams, context, client))
+          .schedulingParams
+      : { isScheduled: false };
+
+    return {
+      contractId,
+      functionParameters,
+      gas: parsedParams.gas,
       schedulingParams,
     };
   }

--- a/packages/core/src/shared/parameter-schemas/dex.zod.ts
+++ b/packages/core/src/shared/parameter-schemas/dex.zod.ts
@@ -1,0 +1,49 @@
+import { Context } from '@/shared/configuration';
+import { z } from 'zod';
+import { optionalScheduledTransactionParams } from './common.zod';
+
+export const swapExactTokensForTokensParameters = (context: Context = {}) =>
+  optionalScheduledTransactionParams(context).extend({
+    routerContractId: z
+      .string()
+      .describe(
+        'The DEX router contract that exposes swapExactTokensForTokens. Accepts a Hedera id (e.g. "0.0.12345") or an EVM address.',
+      ),
+    path: z
+      .array(z.string())
+      .min(2)
+      .describe(
+        'Ordered swap route as token addresses, from the input token to the output token (e.g. ["0.0.111", "0.0.222"]). Each entry may be a Hedera id or an EVM address. Most pairs are a direct [tokenIn, tokenOut] route.',
+      ),
+    amountIn: z
+      .string()
+      .describe(
+        'Exact amount of the input token to swap, expressed in the token\'s smallest unit (base units, no decimals) as an integer string.',
+      ),
+    amountOutMin: z
+      .string()
+      .describe(
+        'Minimum amount of the output token to accept, in the output token\'s smallest unit. Acts as the slippage floor; the swap reverts if the result would be lower.',
+      ),
+    recipientAddress: z
+      .string()
+      .optional()
+      .describe(
+        'Address that receives the output tokens. Accepts a Hedera id or an EVM address. Defaults to the operator/connected account.',
+      ),
+    deadlineSeconds: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Unix timestamp (in seconds) after which the swap is no longer valid. Defaults to 20 minutes from now.',
+      ),
+    gas: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(1_000_000)
+      .describe('Gas limit for the router contract call.'),
+  });

--- a/packages/core/src/shared/parameter-schemas/dex.zod.ts
+++ b/packages/core/src/shared/parameter-schemas/dex.zod.ts
@@ -2,6 +2,28 @@ import { Context } from '@/shared/configuration';
 import { z } from 'zod';
 import { optionalScheduledTransactionParams } from './common.zod';
 
+/**
+ * A token amount in base units.
+ *
+ * These values are fed straight into `BigInt()` by the normaliser, and an LLM
+ * routinely produces `"1.5"` or `"1e10"` when it ignores the "base units"
+ * instruction — both of which throw a raw `SyntaxError` deep in normalisation
+ * instead of surfacing a usable validation error. The regex rejects them at the
+ * schema boundary. It also rejects `""`, which `BigInt()` silently coerces to
+ * `0`, and negative values.
+ */
+const baseUnitAmount = (field: string) =>
+  z
+    .string()
+    .regex(
+      /^\d+$/,
+      `${field} must be an integer string in the token's smallest unit (base units) — no decimals, sign, or exponent`,
+    )
+    // Both checks are plain string checks on purpose. A `.refine()` calling
+    // BigInt() would throw on inputs the regex already rejected: zod runs
+    // refinements even after a preceding regex check fails.
+    .regex(/^(?!0+$)/, `${field} must be greater than zero`);
+
 export const swapExactTokensForTokensParameters = (context: Context = {}) =>
   optionalScheduledTransactionParams(context).extend({
     routerContractId: z
@@ -15,16 +37,14 @@ export const swapExactTokensForTokensParameters = (context: Context = {}) =>
       .describe(
         'Ordered swap route as token addresses, from the input token to the output token (e.g. ["0.0.111", "0.0.222"]). Each entry may be a Hedera id or an EVM address. Most pairs are a direct [tokenIn, tokenOut] route.',
       ),
-    amountIn: z
-      .string()
-      .describe(
-        'Exact amount of the input token to swap, expressed in the token\'s smallest unit (base units, no decimals) as an integer string.',
-      ),
-    amountOutMin: z
-      .string()
-      .describe(
-        'Minimum amount of the output token to accept, in the output token\'s smallest unit. Acts as the slippage floor; the swap reverts if the result would be lower.',
-      ),
+    amountIn: baseUnitAmount('amountIn').describe(
+      "Exact amount of the input token to swap, expressed in the token's smallest unit (base units, no decimals) as a positive integer string.",
+    ),
+    // Must stay strictly positive: this is the slippage floor, and a zero floor
+    // accepts any output amount, leaving the swap open to sandwiching.
+    amountOutMin: baseUnitAmount('amountOutMin').describe(
+      "Minimum amount of the output token to accept, in the output token's smallest unit, as a positive integer string. Acts as the slippage floor; the swap reverts if the result would be lower. Must be greater than zero — a zero floor would accept any output amount.",
+    ),
     recipientAddress: z
       .string()
       .optional()

--- a/packages/core/tests/unit/tools/swap-tokens.unit.test.ts
+++ b/packages/core/tests/unit/tools/swap-tokens.unit.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AccountId, Client, PrivateKey } from '@hiero-ledger/sdk';
+import toolFactory, { SWAP_TOKENS_TOOL } from '@/plugins/core-dex-plugin/tools/swap-tokens';
+import { swapExactTokensForTokensParameters } from '@/shared/parameter-schemas/dex.zod';
+import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
+import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
+import * as TxModeStrategy from '@/shared/strategies/tx-mode-strategy';
+import * as MirrornodeUtils from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
+import { z } from 'zod';
+import { AgentMode } from '@/shared/configuration';
+
+// ---- MOCKS ----
+vi.mock('@/shared/hedera-utils/hedera-parameter-normaliser', () => ({
+  default: {
+    normaliseSwapExactTokensForTokensParams: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/hedera-utils/hedera-builder', () => ({
+  default: {
+    executeTransaction: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/strategies/tx-mode-strategy', () => ({
+  handleTransaction: vi.fn(async (_tx: any, _client: any, _context: any) => {
+    return {
+      raw: {
+        status: 'SUCCESS',
+        transactionId: '0.0.1234@1700000000.000000001',
+      },
+      humanMessage: 'Token swap submitted successfully.',
+    } as any;
+  }),
+}));
+
+vi.mock('@/shared/utils/prompt-generator', () => ({
+  PromptGenerator: {
+    getParameterUsageInstructions: vi.fn(() => 'Usage: Provide parameters as JSON.'),
+    getContextSnippet: vi.fn(() => 'some context'),
+    getScheduledTransactionParamsDescription: vi.fn(
+      () =>
+        '- schedulingParams (object, optional): Set isScheduled = true to make the transaction scheduled.',
+    ),
+  },
+}));
+
+vi.mock('@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils', () => ({
+  getMirrornodeService: vi.fn(() => ({
+    getAccount: vi.fn(),
+  })),
+}));
+
+// ---- SHALLOW MOCKS ----
+const mockedNormaliser = vi.mocked(HederaParameterNormaliser, { deep: false });
+const mockedBuilder = vi.mocked(HederaBuilder, { deep: false });
+const mockedTxStrategy = vi.mocked(TxModeStrategy, { deep: false });
+const mockedMirrornodeUtils = vi.mocked(MirrornodeUtils, { deep: false });
+
+// ---- HELPERS ----
+// ECDSA operator is required by the swap tool (EVM contract call).
+const makeClient = () =>
+  Client.forTestnet().setOperator(AccountId.fromString('0.0.1001'), PrivateKey.generateECDSA());
+
+// ---- TESTS ----
+describe('swapTokens tool (unit)', () => {
+  const context: any = { accountId: '0.0.1001', mode: AgentMode.AUTONOMOUS };
+  const params = {
+    routerContractId: '0.0.12345',
+    path: ['0.0.111', '0.0.222'],
+    amountIn: '100000000',
+    amountOutMin: '95000000',
+  } as unknown as z.infer<ReturnType<typeof swapExactTokensForTokensParameters>>;
+
+  const normalisedParams = {
+    contractId: '0.0.12345',
+    functionParameters: new Uint8Array([0x01, 0x02, 0x03]),
+    gas: 1_000_000,
+    schedulingParams: { isScheduled: false },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedMirrornodeUtils.getMirrornodeService.mockReturnValue({
+      getAccount: vi.fn(),
+    } as any);
+  });
+
+  it('exposes correct metadata', () => {
+    const tool = toolFactory(context);
+    expect(tool.method).toBe(SWAP_TOKENS_TOOL);
+    expect(tool.name).toBe('Swap Tokens');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description).toContain('swapExactTokensForTokens');
+    expect(tool.parameters).toBeTruthy();
+  });
+
+  it('executes happy path and returns success message', async () => {
+    mockedNormaliser.normaliseSwapExactTokensForTokensParams.mockResolvedValue(normalisedParams);
+    mockedBuilder.executeTransaction.mockReturnValue({} as any);
+
+    const tool = toolFactory(context);
+    const client = makeClient();
+
+    const res: any = await tool.execute(client, context, params);
+
+    expect(res).toBeDefined();
+    expect(res.raw).toBeDefined();
+    expect(res.humanMessage).toBe('Token swap submitted successfully.');
+    expect(mockedNormaliser.normaliseSwapExactTokensForTokensParams).toHaveBeenCalledOnce();
+    expect(mockedBuilder.executeTransaction).toHaveBeenCalledOnce();
+    expect(mockedTxStrategy.handleTransaction).toHaveBeenCalledOnce();
+  });
+
+  it('returns a friendly error when normalisation fails', async () => {
+    mockedNormaliser.normaliseSwapExactTokensForTokensParams.mockRejectedValue(
+      new Error('boom'),
+    );
+
+    const tool = toolFactory(context);
+    const client = makeClient();
+
+    const res: any = await tool.execute(client, context, params);
+
+    expect(res.humanMessage).toContain('Failed to swap tokens');
+    expect(res.humanMessage).toContain('boom');
+    expect(mockedBuilder.executeTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/unit/tools/swap-tokens.unit.test.ts
+++ b/packages/core/tests/unit/tools/swap-tokens.unit.test.ts
@@ -113,9 +113,7 @@ describe('swapTokens tool (unit)', () => {
   });
 
   it('returns a friendly error when normalisation fails', async () => {
-    mockedNormaliser.normaliseSwapExactTokensForTokensParams.mockRejectedValue(
-      new Error('boom'),
-    );
+    mockedNormaliser.normaliseSwapExactTokensForTokensParams.mockRejectedValue(new Error('boom'));
 
     const tool = toolFactory(context);
     const client = makeClient();
@@ -125,5 +123,54 @@ describe('swapTokens tool (unit)', () => {
     expect(res.humanMessage).toContain('Failed to swap tokens');
     expect(res.humanMessage).toContain('boom');
     expect(mockedBuilder.executeTransaction).not.toHaveBeenCalled();
+  });
+
+  describe('amount validation', () => {
+    const schema = swapExactTokensForTokensParameters(context);
+    const withAmounts = (amountIn: string, amountOutMin: string) => ({
+      routerContractId: '0.0.12345',
+      path: ['0.0.111', '0.0.222'],
+      amountIn,
+      amountOutMin,
+    });
+
+    it('accepts positive integer base-unit amounts', () => {
+      expect(schema.safeParse(withAmounts('100000000', '95000000')).success).toBe(true);
+    });
+
+    // A zero slippage floor accepts any output amount, which leaves the swap
+    // open to sandwiching. It must not be representable.
+    it('rejects a zero amountOutMin', () => {
+      const result = schema.safeParse(withAmounts('100000000', '0'));
+      expect(result.success).toBe(false);
+      expect(JSON.stringify(result)).toContain('greater than zero');
+    });
+
+    it('rejects a zero amountIn', () => {
+      expect(schema.safeParse(withAmounts('0', '95000000')).success).toBe(false);
+    });
+
+    // BigInt('') is 0, so an empty string would silently become a zero floor.
+    it('rejects an empty amount rather than coercing it to zero', () => {
+      expect(schema.safeParse(withAmounts('100000000', '')).success).toBe(false);
+    });
+
+    // These reach BigInt() and throw a raw SyntaxError without the regex guard.
+    it.each(['abc', '1.5', '1e10', '  7 ', '0x10'])(
+      'rejects non-integer amount %j before it reaches BigInt()',
+      value => {
+        expect(schema.safeParse(withAmounts(value, '95000000')).success).toBe(false);
+      },
+    );
+
+    it('rejects negative amounts', () => {
+      expect(schema.safeParse(withAmounts('-5', '95000000')).success).toBe(false);
+      expect(schema.safeParse(withAmounts('100000000', '-5')).success).toBe(false);
+    });
+
+    it('accepts amounts beyond Number.MAX_SAFE_INTEGER', () => {
+      const huge = '9007199254740993000';
+      expect(schema.safeParse(withAmounts(huge, huge)).success).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## What this does

Adds a minimal token swap tool, addressing #7.

It introduces a small `core-dex-plugin` with a single `swap_tokens_tool` that calls a Uniswap V2 style router's `swapExactTokensForTokens(amountIn, amountOutMin, path, to, deadline)`. It's deliberately vendor-neutral: you pass the router contract, the token route, the amounts, and an optional deadline, so it works with any compatible Hedera DEX (SaucerSwap and similar) without baking in a specific provider.

I kept the surface area intentionally small, in line with the "minimal proof of concept" note on the issue.

## How it works

- New schema `swapExactTokensForTokensParameters` and a `normaliseSwapExactTokensForTokensParams` normaliser that resolves the route + recipient to EVM addresses, encodes the call with `ethers`, and defaults the deadline to 20 minutes out.
- The tool follows the same shape as the existing ERC-20 tools (ECDSA operator assertion, `HederaBuilder.executeTransaction`, mode-aware `handleTransaction`).
- Registered in the plugins barrel and documented in `HEDERATOOLS.md` / `HEDERAPLUGINS.md`.

## A note on allowances

The input token needs an allowance granted to the router before swapping. Rather than bundle that in, the tool documents the prerequisite and points to the existing `approve_token_allowance_tool`, keeping each tool focused.

## Testing

- `pnpm lint:check`, `pnpm build`, and `pnpm test:unit` all pass.
- New unit test covers metadata, the happy path, and error handling.

## Possible follow-ups (out of scope here)

- A dedicated ERC-20 `approve` tool (core currently only has the HTS allowance tool).
- Quote/slippage helpers and multi-hop routing convenience.

Happy to adjust the naming, parameters, or structure to fit your conventions. Thanks for taking a look!
