### PR TITLE
docs(plugins): add hak-uniswap-plugin v0.1.0 — first Uniswap plugin for the Hedera Agent Kit

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -65,6 +65,15 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
   Status: Validated by HAK team, v4-compatible release
 
 
+- [Uniswap Plugin](https://www.npmjs.com/package/hak-uniswap-plugin) is the first Uniswap plugin for the Hedera Agent Kit, letting a Hedera agent swap tokens through Uniswap permissionless liquidity on EVM chains (Ethereum, Unichain, Base, …). It exposes the action (`uniswap_swap`) with a quote → dynamic ERC-20 allowance → execute flow for cross-asset settlement and treasury rebalancing, plus an optional Ledger Clear-Sign gate for above-threshold swaps:
+
+  NPM: https://www.npmjs.com/package/hak-uniswap-plugin
+
+  Github repository: https://github.com/jmgomezl/hak-uniswap-plugin
+
+  Version: hak-uniswap-plugin@0.1.0
+
+
 - [CoinCap Plugin](https://www.npmjs.com/package/coincap-hedera-plugin) provides access to the [**CoinCap API service**](https://www.coincap.io) to access cryptocurrency market data. It exposes the action (`get HBAR price in USD`) to get the current price of HBAR in USD currency, by using it you can ask your agent to get your current HBAR balance expressed in USD.
 
   NPM: https://www.npmjs.com/package/coincap-hedera-plugin


### PR DESCRIPTION
Adds `hak-uniswap-plugin` to the third-party plugins list in `docs/PLUGINS.md`.

**What it does:** lets a Hedera Agent Kit agent swap tokens through Uniswap's permissionless liquidity on EVM chains — the first Uniswap plugin in the HAK ecosystem. One tool, `uniswap_swap`: quote → **dynamic ERC-20 allowance/approval** → execute, with an optional **Ledger Clear-Sign gate** for above-threshold swaps. Enables cross-asset settlement and treasury rebalancing for Hedera agents.

- **NPM:** https://www.npmjs.com/package/hak-uniswap-plugin
- **Source:** https://github.com/jmgomezl/hak-uniswap-plugin
- **Version:** `hak-uniswap-plugin@0.1.0`

**Validated** with real on-chain swaps (native ETH → USDC, Ethereum Sepolia):
- [`0x69babe82…2ea5fc`](https://sepolia.etherscan.io/tx/0x69babe822b2a418696c8ff2e0064a646f6c3747bc9e54659ee5beb99de2ea5fc) — SUCCESS, block 11049036
- [`0xb1dc8201…ccbd9e`](https://sepolia.etherscan.io/tx/0xb1dc82013663110221d8039f2873e4f64ba742485ba8b4275a70f3d214ccbd9e) — SUCCESS, block 11053763 — fired automatically as the cross-asset settlement leg of a live [Kickoff.bot](https://kickoff.bot) deal, recorded back on Hedera HCS-10.

Docs-only change, following the existing third-party plugin entry format. Commit is DCO signed-off.