### PR TITLE
docs(plugins): add hak-ledger-plugin v0.1.0 — first Ledger plugin for the Hedera Agent Kit

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -107,6 +107,14 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Status: Validated by HAK team, v4-compatible release
 
+- [Ledger Plugin](https://www.npmjs.com/package/hak-ledger-plugin) is the first Ledger hardware-wallet plugin for the Hedera Agent Kit — a human-in-the-loop signer that Clear-Signs high-risk EVM transactions on a physical Ledger before the agent executes them, exposing `ledger_clear_sign` (Clear-Sign + optionally broadcast an unsigned EVM tx; the device is the final gate) and `ledger_get_address` (derive + verify a hardware-backed EVM identity). Pairs with `hak-uniswap-plugin`'s `requires_ledger_approval` flow for device-gated, above-threshold settlement:
+
+  NPM: https://www.npmjs.com/package/hak-ledger-plugin
+
+  Github repository: https://github.com/jmgomezl/hak-ledger-plugin
+
+  Version: hak-ledger-plugin@0.1.0
+
 ## Plugin Architecture
 
 The tools are now organized into plugins, each containing a set functionality related to the Hedera service or project they are created for.


### PR DESCRIPTION
Adds `hak-ledger-plugin` to the third-party plugins list in `docs/PLUGINS.md`.

**What it does:** a human-in-the-loop **Ledger hardware-wallet** signer for Hedera Agent Kit agents — the first Ledger plugin in the HAK ecosystem. A high-risk EVM transaction is **Clear-Signed on a physical Ledger** before the agent executes it, so the device is the final confirmation gate.

Two tools:
- `ledger_clear_sign` — Clear-Sign an unsigned EVM transaction on the device and (optionally) broadcast it. Returns `executed` / `signed` / `rejected` (if the human declines on-device).
- `ledger_get_address` — derive + verify a hardware-backed EVM identity.

Pairs with `hak-uniswap-plugin`'s `requires_ledger_approval` flow: feed its `unsignedTx` straight into `ledger_clear_sign` for device-gated, above-threshold settlement. USB via `@ledgerhq/hw-transport-node-hid`; WebHID/Speculos via an injected `context.ledgerTransport`.

- **NPM:** https://www.npmjs.com/package/hak-ledger-plugin
- **Source:** https://github.com/jmgomezl/hak-ledger-plugin
- **Version:** `hak-ledger-plugin@0.1.0`

Docs-only change, following the existing third-party plugin entry format. Commit is DCO signed-off.