### PR TITLE
feat(core): add classifyToolResult helper for typed tool result envelopes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,9 @@ export { PromptGenerator } from './shared/utils/prompt-generator';
 export {
   transactionToolOutputParser,
   untypedQueryOutputParser,
+  classifyToolResult,
 } from './shared/utils/default-tool-output-parsing';
+export type { ToolResultStatus } from './shared/utils/default-tool-output-parsing';
 export { IHederaMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface';
 export { getMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
 export { HederaMirrornodeServiceDefaultImpl } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl';

--- a/packages/core/src/shared/utils/default-tool-output-parsing.ts
+++ b/packages/core/src/shared/utils/default-tool-output-parsing.ts
@@ -123,3 +123,96 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
     humanMessage: parsedObject.humanMessage,
   };
 };
+
+/**
+ * Discriminated union describing a tool result that has been classified into
+ * a stable success / failure / parse_error shape.
+ *
+ * - `success`: the underlying tool reported a non-error status. `data` exposes
+ *   the original `raw` payload typed as `T`. `transactionId` is lifted out
+ *   when present so consumers don't need to know which sub-field carries it.
+ * - `failure`: the tool surfaced an error — either an SDK `Status` object
+ *   (`raw.status` is an object with a numeric `_code`, e.g. `Status.InvalidTransaction`)
+ *   or an explicit `raw.error` string. `errorCode` is normalised to the
+ *   numeric SDK code when available, falling back to the string status.
+ * - `parse_error`: the upstream parser could not interpret the tool output
+ *   (`raw.status === 'PARSE_ERROR'`) or the envelope was malformed.
+ */
+export type ToolResultStatus<T = unknown> =
+  | { kind: 'success'; transactionId?: string; data: T; humanMessage: string }
+  | { kind: 'failure'; errorCode: number | string; error: string; humanMessage: string }
+  | { kind: 'parse_error'; originalOutput: unknown; humanMessage: string };
+
+/**
+ * Classify the `{ raw, humanMessage }` envelope returned by
+ * {@link transactionToolOutputParser} or {@link untypedQueryOutputParser}
+ * into a typed, discriminated `ToolResultStatus<T>`.
+ *
+ * This is an **additive, opt-in** helper. Existing parsers continue to return
+ * `{ raw: any; humanMessage: string }` unchanged. Consumers that want a
+ * single, type-safe surface for branching on success vs. failure can pass
+ * that envelope here and `switch` on `kind`.
+ *
+ * @example
+ * ```ts
+ * const envelope = transactionToolOutputParser(rawOutput);
+ * const result = classifyToolResult<{ transactionId: string; topicId?: string }>(envelope);
+ * switch (result.kind) {
+ *   case 'success':
+ *     return { txId: result.transactionId, topicId: result.data.topicId };
+ *   case 'failure':
+ *     throw new Error(`tool failed (${result.errorCode}): ${result.error}`);
+ *   case 'parse_error':
+ *     throw new Error(`tool output unparseable: ${result.humanMessage}`);
+ * }
+ * ```
+ *
+ * @param parsed The envelope returned by one of the default tool parsers.
+ * @returns A `ToolResultStatus<T>` tagged union safe to `switch` on.
+ */
+export const classifyToolResult = <T = unknown>(parsed: {
+  raw: any;
+  humanMessage: string;
+}): ToolResultStatus<T> => {
+  const humanMessage = parsed?.humanMessage ?? '';
+  const raw = parsed?.raw;
+
+  if (raw == null || typeof raw !== 'object') {
+    return {
+      kind: 'parse_error',
+      originalOutput: raw,
+      humanMessage: humanMessage || 'Error: Tool output had an unexpected format.',
+    };
+  }
+
+  if (raw.status === 'PARSE_ERROR') {
+    return {
+      kind: 'parse_error',
+      originalOutput: 'originalOutput' in raw ? raw.originalOutput : raw,
+      humanMessage,
+    };
+  }
+
+  const statusIsObject = raw.status !== null && typeof raw.status === 'object';
+  if (statusIsObject || typeof raw.error === 'string') {
+    const errorCode =
+      statusIsObject && '_code' in (raw.status as object)
+        ? (raw.status as { _code: number })._code
+        : typeof raw.status === 'string'
+          ? raw.status
+          : 'UNKNOWN';
+    return {
+      kind: 'failure',
+      errorCode,
+      error: typeof raw.error === 'string' ? raw.error : humanMessage,
+      humanMessage,
+    };
+  }
+
+  return {
+    kind: 'success',
+    transactionId: typeof raw.transactionId === 'string' ? raw.transactionId : undefined,
+    data: raw as T,
+    humanMessage,
+  };
+};

--- a/packages/core/src/shared/utils/index.ts
+++ b/packages/core/src/shared/utils/index.ts
@@ -2,3 +2,5 @@ export { AccountResolver } from './account-resolver';
 export { PromptGenerator } from './prompt-generator';
 export { transactionToolOutputParser } from './default-tool-output-parsing';
 export { untypedQueryOutputParser } from './default-tool-output-parsing';
+export { classifyToolResult } from './default-tool-output-parsing';
+export type { ToolResultStatus } from './default-tool-output-parsing';

--- a/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
+++ b/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyToolResult,
+  transactionToolOutputParser,
+  type ToolResultStatus,
+} from '@/shared/utils/default-tool-output-parsing';
+
+describe('classifyToolResult', () => {
+  describe('success', () => {
+    it('classifies a SUCCESS-status envelope as success and lifts transactionId', () => {
+      const result = classifyToolResult({
+        raw: { status: 'SUCCESS', transactionId: '0.0.1234@1700000000.000000001' },
+        humanMessage:
+          'Message submitted successfully with transaction id 0.0.1234@1700000000.000000001',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.transactionId).toBe('0.0.1234@1700000000.000000001');
+        expect(result.humanMessage).toContain('Message submitted');
+        expect(result.data).toMatchObject({ status: 'SUCCESS' });
+      }
+    });
+
+    it('returns success with undefined transactionId when none is present', () => {
+      const result = classifyToolResult({
+        raw: { status: 'SUCCESS', topicId: '0.0.5678' },
+        humanMessage: 'Topic created',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.transactionId).toBeUndefined();
+      }
+    });
+
+    it('preserves the full raw payload via the typed `data` field', () => {
+      type CreateTopicData = { status: string; topicId: string; transactionId: string };
+      const result = classifyToolResult<CreateTopicData>({
+        raw: { status: 'SUCCESS', topicId: '0.0.5678', transactionId: '0.0.1@2.3' },
+        humanMessage: 'Topic created',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        // Type narrowing: data is typed as CreateTopicData here
+        expect(result.data.topicId).toBe('0.0.5678');
+        expect(result.data.transactionId).toBe('0.0.1@2.3');
+      }
+    });
+
+    it('treats RETURN_BYTES mode (no status field, has bytes) as success', () => {
+      const result = classifyToolResult({
+        raw: { bytes: new Uint8Array([1, 2, 3]) },
+        humanMessage: 'Transaction bytes are ready for signing.',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.transactionId).toBeUndefined();
+        expect((result.data as { bytes: Uint8Array }).bytes).toBeInstanceOf(Uint8Array);
+      }
+    });
+  });
+
+  describe('failure', () => {
+    it('classifies an SDK Status object (e.g. InvalidTransaction) as failure with numeric code', () => {
+      const result = classifyToolResult({
+        raw: {
+          status: { _code: 1 },
+          error: 'Failed to submit message to topic: INVALID_TRANSACTION',
+        },
+        humanMessage: 'Failed to submit message to topic: INVALID_TRANSACTION',
+      });
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.errorCode).toBe(1);
+        expect(result.error).toContain('INVALID_TRANSACTION');
+        expect(result.humanMessage).toContain('Failed to submit');
+      }
+    });
+
+    it('falls back to humanMessage as `error` when raw.error is missing', () => {
+      const result = classifyToolResult({
+        raw: { status: { _code: 9 } },
+        humanMessage: 'something went wrong',
+      });
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.errorCode).toBe(9);
+        expect(result.error).toBe('something went wrong');
+      }
+    });
+
+    it('classifies envelope with raw.error string (no status object) as failure', () => {
+      const result = classifyToolResult({
+        raw: { error: 'Network unreachable' },
+        humanMessage: 'Network unreachable',
+      });
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.errorCode).toBe('UNKNOWN');
+        expect(result.error).toBe('Network unreachable');
+      }
+    });
+  });
+
+  describe('parse_error', () => {
+    it('classifies PARSE_ERROR-status envelopes as parse_error', () => {
+      const result = classifyToolResult({
+        raw: {
+          status: 'PARSE_ERROR',
+          error: new SyntaxError('Unexpected token'),
+          originalOutput: 'not-json{',
+        },
+        humanMessage: 'Error: Failed to parse tool output. The output was malformed.',
+      });
+
+      expect(result.kind).toBe('parse_error');
+      if (result.kind === 'parse_error') {
+        expect(result.originalOutput).toBe('not-json{');
+        expect(result.humanMessage).toContain('Failed to parse');
+      }
+    });
+
+    it('classifies missing/null raw as parse_error', () => {
+      const result = classifyToolResult({ raw: null as unknown as object, humanMessage: '' });
+      expect(result.kind).toBe('parse_error');
+    });
+
+    it('classifies non-object raw (string) as parse_error', () => {
+      const result = classifyToolResult({ raw: 'oops' as unknown as object, humanMessage: '' });
+      expect(result.kind).toBe('parse_error');
+      if (result.kind === 'parse_error') {
+        expect(result.originalOutput).toBe('oops');
+        expect(result.humanMessage).toContain('unexpected format');
+      }
+    });
+  });
+
+  describe('end-to-end with transactionToolOutputParser', () => {
+    it('classifies the parser output of a successful submit_topic_message_tool', () => {
+      // Shape produced by the kit when a transaction succeeds in EXECUTE_TRANSACTION mode.
+      const rawOutput = JSON.stringify({
+        raw: { status: 'SUCCESS', transactionId: '0.0.1234@1700.0' },
+        humanMessage: 'Message submitted successfully with transaction id 0.0.1234@1700.0',
+      });
+      const envelope = transactionToolOutputParser(rawOutput);
+      const result: ToolResultStatus = classifyToolResult(envelope);
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.transactionId).toBe('0.0.1234@1700.0');
+      }
+    });
+
+    it('classifies a malformed parser input as parse_error end-to-end', () => {
+      const envelope = transactionToolOutputParser('not-json{');
+      const result = classifyToolResult(envelope);
+      expect(result.kind).toBe('parse_error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **additive, opt-in** helper — `classifyToolResult<T>()` — that turns the existing `{ raw, humanMessage }` envelope returned by `transactionToolOutputParser` / `untypedQueryOutputParser` into a discriminated `ToolResultStatus<T>` tagged union:

```ts
type ToolResultStatus<T = unknown> =
  | { kind: 'success'; transactionId?: string; data: T; humanMessage: string }
  | { kind: 'failure'; errorCode: number | string; error: string; humanMessage: string }
  | { kind: 'parse_error'; originalOutput: unknown; humanMessage: string };
```

This is the smallest step toward the explicit roadmap already documented in the JSDoc of `default-tool-output-parsing.ts`:

> *"The long-term goal is to replace this with **specific, strongly-typed output parsers for each individual query tool**. This will allow for better compile-time type-checking and more robust handling of each tool's unique `raw` data structure."*

## Why

Today the `raw.status` discriminator changes shape between success and failure:

```jsonc
// Success — submit_topic_message_tool
{ "raw": { "status": "SUCCESS", "transactionId": "0.0.xxx@123.456" }, ... }

// Failure (handleError in submit-topic-message.ts):
{ "raw": { "status": Status.InvalidTransaction /* { _code: 1 } */, "error": "..." }, ... }
```

Every consumer has to duck-type on which sub-fields exist. We hit the production cost of this in the LENITNES integration ([issue #967](https://github.com/hashgraph/hedera-agent-kit-js/issues/967) §1): a stat that reported "100% HCS-proofed" while every write was silently failing, because the discriminator difference was missed.

`classifyToolResult()` gives consumers a single, type-safe surface to `switch` on, with the success-case `transactionId` lifted out so call sites don't need to know which sub-field carries it.

## Scope

**Pure additive.** Zero existing behavior changes — `transactionToolOutputParser` and `untypedQueryOutputParser` continue to return `{ raw: any; humanMessage: string }` unchanged. Adoption is opt-in; nothing forces consumers to migrate.

- \`packages/core/src/shared/utils/default-tool-output-parsing.ts\` — adds \`ToolResultStatus<T>\` type + \`classifyToolResult<T>()\` function (~80 lines)
- \`packages/core/src/shared/utils/index.ts\` — re-exports the new symbols
- \`packages/core/src/index.ts\` — re-exports the new symbols from the package root (next to \`transactionToolOutputParser\`)
- \`packages/core/tests/unit/utils/classify-tool-result.unit.test.ts\` — **12 new unit tests**: success / failure (SDK \`Status\` object + plain \`error\` string) / parse_error / RETURN_BYTES mode / end-to-end through \`transactionToolOutputParser\`

## Example

```ts
import { transactionToolOutputParser, classifyToolResult } from '@hashgraph/hedera-agent-kit';

const envelope = transactionToolOutputParser(rawOutput);
const result = classifyToolResult<{ transactionId: string; topicId?: string }>(envelope);

switch (result.kind) {
  case 'success':
    return { txId: result.transactionId, topicId: result.data.topicId };
  case 'failure':
    throw new Error(\`tool failed (\${result.errorCode}): \${result.error}\`);
  case 'parse_error':
    throw new Error(\`tool output unparseable: \${result.humanMessage}\`);
}
```

## Test plan

- [x] \`pnpm --filter @hashgraph/hedera-agent-kit vitest run tests/unit/utils/classify-tool-result.unit.test.ts\` — 12/12 pass
- [x] \`pnpm --filter @hashgraph/hedera-agent-kit lint:check\` — clean
- [x] \`pnpm --filter @hashgraph/hedera-agent-kit format:check\` — clean for files in this PR
- [x] Full \`test:unit\` run: 508/508 tests pass; only failure is the pre-existing \`tests/unit/utils/decimals-utils.unit.test.ts\` package-resolution issue (reproduces unchanged on \`main\` — unrelated to this PR)

## DCO

Commit is signed-off (\`Signed-off-by:\` trailer).

## Related

Refs #967 — production feedback writeup from LENITNES (Hedera AI Bounty submission).