### PR TITLE
fix(deps): avoid duplicate framework copies via peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Open `package.json` and add `"type": "module"` to enable ES modules.
 Install the core package, LangChain toolkit, your LLM provider, and the Hedera SDK:
 
 ```bash
-npm install @hiero-ledger/sdk @hashgraph/hedera-agent-kit @hashgraph/hedera-agent-kit-langchain @langchain/openai dotenv
+npm install @hiero-ledger/sdk @hashgraph/hedera-agent-kit @hashgraph/hedera-agent-kit-langchain langchain @langchain/openai dotenv
 ```
 
 > Using a different LLM? Replace `@langchain/openai` with `@langchain/anthropic`, `@langchain/groq`, or `@langchain/ollama`.

--- a/packages/adk/package.json
+++ b/packages/adk/package.json
@@ -45,13 +45,14 @@
         "dist/**/*"
     ],
     "dependencies": {
-        "@hashgraph/hedera-agent-kit": "workspace:*",
-        "@google/adk": "0.6.1"
+        "@hashgraph/hedera-agent-kit": "workspace:*"
     },
     "peerDependencies": {
-        "@hiero-ledger/sdk": "^2.81.0"
+        "@hiero-ledger/sdk": "^2.81.0",
+        "@google/adk": "^0.6.1"
     },
     "devDependencies": {
+        "@google/adk": "0.6.1",
         "@hiero-ledger/sdk": "2.81.0",
         "tsup": "8.5.0",
         "typescript": "5.8.3",

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -7,7 +7,7 @@ Vercel AI SDK integration for Hedera Agent Kit. Wraps Hedera tools as Vercel AI 
 ### 1. Install dependencies
 
 ```bash
-npm install @hashgraph/hedera-agent-kit-ai-sdk @hashgraph/hedera-agent-kit @hiero-ledger/sdk @ai-sdk/openai dotenv
+npm install @hashgraph/hedera-agent-kit-ai-sdk @hashgraph/hedera-agent-kit @hiero-ledger/sdk ai @ai-sdk/openai dotenv
 ```
 
 ### 2. Configure environment variables

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -51,14 +51,15 @@
     "@ai-sdk/mcp": "1.0.21",
     "@hashgraph/hedera-agent-kit": "workspace:*",
     "@modelcontextprotocol/sdk": "1.27.1",
-    "ai": "6.0.86",
     "zod": "3.25.76"
   },
   "peerDependencies": {
-    "@hiero-ledger/sdk": "^2.81.0"
+    "@hiero-ledger/sdk": "^2.81.0",
+    "ai": "^6.0.86"
   },
   "devDependencies": {
     "@hiero-ledger/sdk": "2.81.0",
+    "ai": "6.0.86",
     "tsup": "8.5.0",
     "typescript": "5.8.3",
     "vitest": "4.0.16"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -142,7 +142,7 @@ Open `package.json` and add `"type": "module"` to enable ES modules.
 Install the core package, LangChain toolkit, your LLM provider, and the Hedera SDK:
 
 ```bash
-npm install @hiero-ledger/sdk @hashgraph/hedera-agent-kit @hashgraph/hedera-agent-kit-langchain @langchain/openai dotenv
+npm install @hiero-ledger/sdk @hashgraph/hedera-agent-kit @hashgraph/hedera-agent-kit-langchain langchain @langchain/openai dotenv
 ```
 
 > Using a different LLM? Replace `@langchain/openai` with `@langchain/anthropic`, `@langchain/groq`, or `@langchain/ollama`.

--- a/packages/elizaos/package.json
+++ b/packages/elizaos/package.json
@@ -48,14 +48,16 @@
     "dist/**/*"
   ],
   "dependencies": {
-    "@elizaos/core": "1.7.2",
     "@hashgraph/hedera-agent-kit": "workspace:*",
+    "zod": "3.25.76",
     "zod-to-json-schema": "3.24.6"
   },
   "peerDependencies": {
+    "@elizaos/core": "^1.7.2",
     "@hiero-ledger/sdk": "^2.81.0"
   },
   "devDependencies": {
+    "@elizaos/core": "1.7.2",
     "@hiero-ledger/sdk": "2.81.0",
     "tsup": "8.5.0",
     "typescript": "5.8.3",

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -7,7 +7,7 @@ LangChain integration for Hedera Agent Kit. Wraps Hedera tools as LangChain `Str
 ### 1. Install dependencies
 
 ```bash
-npm install @hashgraph/hedera-agent-kit-langchain @hashgraph/hedera-agent-kit @hiero-ledger/sdk @langchain/openai dotenv
+npm install @hashgraph/hedera-agent-kit-langchain @hashgraph/hedera-agent-kit @hiero-ledger/sdk langchain @langchain/openai dotenv
 ```
 
 ### 2. Configure environment variables

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -49,20 +49,22 @@
   ],
   "dependencies": {
     "@hashgraph/hedera-agent-kit": "workspace:*",
-    "@langchain/core": "1.1.24",
     "@langchain/mcp-adapters": "1.1.3",
     "@modelcontextprotocol/sdk": "1.27.1",
-    "langchain": "1.2.24",
     "zod": "3.25.76"
   },
   "peerDependencies": {
-    "@hiero-ledger/sdk": "^2.81.0"
+    "@hiero-ledger/sdk": "^2.81.0",
+    "@langchain/core": "^1.1.24",
+    "langchain": "^1.2.24"
   },
   "devDependencies": {
     "@hashgraph/hedera-agent-kit-tests": "workspace:*",
     "@hiero-ledger/sdk": "2.81.0",
+    "@langchain/core": "1.1.24",
     "@langchain/openai": "1.2.7",
     "dotenv": "17.2.1",
+    "langchain": "1.2.24",
     "tsup": "8.5.0",
     "typescript": "5.8.3",
     "vitest": "4.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,13 +38,13 @@ importers:
 
   packages/adk:
     dependencies:
-      '@google/adk':
-        specifier: 0.6.1
-        version: 0.6.1(4r5avhpcfgcpaxua5fhqfazvhq)
       '@hashgraph/hedera-agent-kit':
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@google/adk':
+        specifier: 0.6.1
+        version: 0.6.1(4r5avhpcfgcpaxua5fhqfazvhq)
       '@hiero-ledger/sdk':
         specifier: 2.81.0
         version: 2.81.0(bn.js@5.2.3)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))
@@ -69,9 +69,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.27.1
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      ai:
-        specifier: 6.0.86
-        version: 6.0.86(zod@3.25.76)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -79,6 +76,9 @@ importers:
       '@hiero-ledger/sdk':
         specifier: 2.81.0
         version: 2.81.0(bn.js@5.2.3)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))
+      ai:
+        specifier: 6.0.86
+        version: 6.0.86(zod@3.25.76)
       tsup:
         specifier: 8.5.0
         version: 8.5.0(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
@@ -199,16 +199,19 @@ importers:
 
   packages/elizaos:
     dependencies:
-      '@elizaos/core':
-        specifier: 1.7.2
-        version: 1.7.2(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@hashgraph/hedera-agent-kit':
         specifier: workspace:*
         version: link:../core
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
       zod-to-json-schema:
         specifier: 3.24.6
-        version: 3.24.6(zod@4.3.6)
+        version: 3.24.6(zod@3.25.76)
     devDependencies:
+      '@elizaos/core':
+        specifier: 1.7.2
+        version: 1.7.2(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
       '@hiero-ledger/sdk':
         specifier: 2.81.0
         version: 2.81.0(bn.js@5.2.3)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))
@@ -227,18 +230,12 @@ importers:
       '@hashgraph/hedera-agent-kit':
         specifier: workspace:*
         version: link:../core
-      '@langchain/core':
-        specifier: 1.1.24
-        version: 1.1.24(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
       '@langchain/mcp-adapters':
         specifier: 1.1.3
         version: 1.1.3(@cfworker/json-schema@4.1.1)(@langchain/core@1.1.24(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@langchain/langgraph@1.2.8(@langchain/core@1.1.24(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(react-dom@19.1.2(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76))
       '@modelcontextprotocol/sdk':
         specifier: 1.27.1
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      langchain:
-        specifier: 1.2.24
-        version: 1.2.24(@langchain/core@1.1.24(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(react-dom@19.1.2(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@3.25.76))
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -249,12 +246,18 @@ importers:
       '@hiero-ledger/sdk':
         specifier: 2.81.0
         version: 2.81.0(bn.js@5.2.3)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))
+      '@langchain/core':
+        specifier: 1.1.24
+        version: 1.1.24(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
       '@langchain/openai':
         specifier: 1.2.7
         version: 1.2.7(@langchain/core@1.1.24(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(ws@8.20.0)
       dotenv:
         specifier: 17.2.1
         version: 17.2.1
+      langchain:
+        specifier: 1.2.24
+        version: 1.2.24(@langchain/core@1.1.24(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(react-dom@19.1.2(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@3.25.76))
       long:
         specifier: 5.3.2
         version: 5.3.2
@@ -5520,10 +5523,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -6130,10 +6135,10 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
-  '@elizaos/core@1.7.2(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@elizaos/core@1.7.2(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+      '@langchain/core': 1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
+      '@langchain/textsplitters': 1.0.1(@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))
       adze: 2.3.0
       crypto-browserify: 3.12.1
       dotenv: 17.4.1
@@ -6833,7 +6838,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -6841,11 +6846,11 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.18(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.5.18(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 11.1.0
-      zod: 4.3.6
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -6907,9 +6912,9 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@langchain/textsplitters@1.0.1(@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.39(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@3.25.76))(ws@8.20.0)
       js-tiktoken: 1.0.21
 
   '@mikro-orm/core@6.6.12':
@@ -10099,16 +10104,6 @@ snapshots:
       openai: 6.34.0(ws@8.20.0)(zod@3.25.76)
       ws: 8.20.0
 
-  langsmith@0.5.18(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
-    dependencies:
-      p-queue: 6.6.2
-      uuid: 10.0.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.0)
-      openai: 6.34.0(ws@8.20.0)(zod@4.3.6)
-      ws: 8.20.0
-
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -10757,12 +10752,6 @@ snapshots:
     optionalDependencies:
       ws: 8.20.0
       zod: 3.25.76
-
-  openai@6.34.0(ws@8.20.0)(zod@4.3.6):
-    optionalDependencies:
-      ws: 8.20.0
-      zod: 4.3.6
-    optional: true
 
   optionator@0.9.4:
     dependencies:
@@ -12152,10 +12141,6 @@ snapshots:
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.24.6(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
Related to: #837 
# Move shared framework packages to `peerDependencies` to prevent duplicate copies downstream

## Summary

Every published integration package declares its host framework as a **regular, exactly-pinned `dependency`**. Because a published library ships its `package.json` — not its lockfile — to consumers, these exact pins force a second, private copy of the framework into any consumer app that also uses that framework directly (which is always the case). Two copies of the same package = two distinct class/type identities, which breaks `instanceof` checks and TypeScript structural matching.

This is the root cause of the reported LangChain issue: `toolkit.getTools()` no longer type-matches `createAgent`'s `tools` parameter, forcing an `as unknown as ClientTool[]` cast. The same latent problem exists in the AI SDK, ADK, and ElizaOS packages.

This PR moves those packages to `peerDependencies` (as ranges), keeping an exact pin in `devDependencies` so the repo's own build stays fully locked via `pnpm-lock.yaml`. This mirrors how `@hiero-ledger/sdk` is **already** handled in every package.

## The problem

A consumer building a LangChain agent installs both `@hashgraph/hedera-agent-kit-langchain` and a current `langchain@1.x` (which depends on `@langchain/core@^1.1.47`). The kit pins `@langchain/core@1.1.24` exactly, so the two ranges don't intersect and the package manager installs two copies:

```
consumer-app/
├── node_modules/
│   ├── langchain/                     → needs @langchain/core@^1.1.47
│   ├── @langchain/core@1.1.47         ← consumer's copy
│   └── @hashgraph/hedera-agent-kit-langchain/
│       └── node_modules/
│           └── @langchain/core@1.1.24 ← second copy forced by our exact pin
```

The `Tool`/`StructuredTool` base class differs between the two copies, so the toolkit's tools are not assignable to `createAgent`'s parameter.

### Why exact pins are correct elsewhere but wrong here

Exact version locking is a deliberate repo convention and it is correct for **reproducibility of the repo's own builds** — but that reproducibility is provided by `pnpm-lock.yaml`, not by the pin in `package.json`. Consumers never receive our lockfile; they only inherit the ranges in our published `package.json`. An exact pin in a *library's* `dependencies` therefore doesn't buy reproducibility for anyone — it only dictates an exact transitive version to consumers and prevents deduplication.

### The rule

A dependency belongs in `peerDependencies` when the library and the consumer **must share a single instance** — i.e. its objects/types cross the boundary between them (`instanceof`, structural typing, plugin/runtime registration). It belongs in `dependencies` when it is a private implementation detail the consumer never touches.

`@hiero-ledger/sdk` already follows this rule (peer `^2.81.0` + dev exact `2.81.0`) because `Client`/`Transaction` objects flow across the boundary. The host frameworks below are in exactly the same category.

## The fix

For each affected package, apply the same pattern already used for `@hiero-ledger/sdk`:

- `peerDependencies`: caret range (`^x.y.z`) — the compatibility contract with the consumer, so their single copy satisfies it.
- `devDependencies`: exact (`x.y.z`) — what the repo builds/tests against, kept locked by the lockfile.
- Removed from `dependencies`.

### Changes per package

| Package | Moved to `peerDependencies` (range) + `devDependencies` (exact) | Why it crosses the boundary |
|---|---|---|
| `langchain` | `@langchain/core`, `langchain` | `StructuredTool` instances flow into `createAgent` |
| `ai-sdk` | `ai` | Tools flow into `generateText`/`streamText` |
| `adk` | `@google/adk` | Tools/types are registered into the consumer's ADK runtime |
| `elizaos` | `@elizaos/core` | The plugin is loaded into the consumer's ElizaOS runtime |
