### PR TITLE
docs(hooks): clarify HcsAuditTrailHook is AUTONOMOUS-only and needs a…

### DIFF
--- a/packages/core/src/hooks/hcs-audit-trail-hook.ts
+++ b/packages/core/src/hooks/hcs-audit-trail-hook.ts
@@ -10,8 +10,18 @@ import { Client, TopicMessageSubmitTransaction } from '@hiero-ledger/sdk';
 /**
  * Hook to add an audit trail of tool executions to a Hedera Consensus Service (HCS) topic.
  *
+ * @remarks
+ * **Autonomous mode only.** This hook works only when the agent runs in `AgentMode.AUTONOMOUS`.
+ * In `RETURN_BYTES` mode it throws before the tool executes, because there is no submitted
+ * transaction to audit.
+ *
+ * **Requires a pre-existing topic.** The hook does not create an HCS topic. Create the topic
+ * first — via the `create_topic_tool`.
+ *
  * @warning If a paid topic (HIP-991: https://hips.hedera.com/hip/hip-991) is provided,
  * it could potentially drain the provided logging client's funds due to message submission fees.
+ *
+ * @see docs/HOOKS_AND_POLICIES.md — "HcsAuditTrailHook" for full setup and examples.
  */
 export class HcsAuditTrailHook extends AbstractHook {
   relevantTools: string[];
@@ -20,6 +30,12 @@ export class HcsAuditTrailHook extends AbstractHook {
   hcsTopicId: string;
   loggingClient?: Client;
 
+  /**
+   * @param relevantTools Tool names to audit (e.g. `['transfer_hbar', 'create_token']`).
+   * @param hcsTopicId Id of a **pre-existing** HCS topic to log to — the hook does not create it.
+   * @param loggingClient Optional client used to submit audit messages; defaults to the agent's
+   *   operator client. Must be allowed to submit to `hcsTopicId`.
+   */
   constructor(relevantTools: string[], hcsTopicId: string, loggingClient?: Client) {
     super();
     this.relevantTools = relevantTools;


### PR DESCRIPTION
Related to: #837

## Summary

Adds JSDoc to `HcsAuditTrailHook` (`packages/core/src/hooks/hcs-audit-trail-hook.ts`) making its two setup requirements visible where developers actually meet them — the class and constructor, via IDE hover/autocomplete. Documentation only; no behavior change.

## Why

Feedback from a developer who built a full agent on the kit:

> `HcsAuditTrailHook` requires a pre-existing topic. It doesn't create one, and it throws outside `AUTONOMOUS` mode. A `createTopicIfMissing` option, or a small documented helper to bootstrap the topic, would smooth the setup.

Both constraints are real:

- The constructor takes a required `hcsTopicId` and never creates a topic.
- `preToolExecutionHook` throws when the agent runs in `RETURN_BYTES` mode — the hook is `AUTONOMOUS`-only.

The dedicated guide `docs/HOOKS_AND_POLICIES.md` **already** documents both (an "Autonomous Mode Only" note and a "Topic Creation: must be created before initializing the hook" prerequisite). The gap was the **source JSDoc**: it only warned about paid topics, so a developer using the hook through editor tooling — as the reporter did — never saw either constraint. This PR closes that gap rather than duplicating the prose docs.

## Changes

`packages/core/src/hooks/hcs-audit-trail-hook.ts`:

- Class JSDoc: added an `@remarks` block stating the hook is **AUTONOMOUS-only** (throws in `RETURN_BYTES`) and **requires a pre-existing topic** (create it via `create_topic_tool` / `TopicCreateTransaction` and pass its id; the client must be allowed to submit). Kept the existing HIP-991 paid-topic warning and added an `@see` link to `docs/HOOKS_AND_POLICIES.md`.
- Constructor JSDoc: `@param` descriptions for `relevantTools`, `hcsTopicId` (noting it must be **pre-existing**), and `loggingClient`.

## Scope / follow-ups

This is the documentation-only remediation for the feedback. The reporter also floated a `createTopicIfMissing` option (auto-creating the topic) — deliberately **out of scope** here; it's a behavior change that can be considered separately if there's demand.

## Testing

None required — comment-only change, no runtime or type impact.
