### PR TITLE
feat(langchain): expose tool name in stream events via event.metadata.hakToolName

### DIFF
--- a/examples/langchain-v1/package-lock.json
+++ b/examples/langchain-v1/package-lock.json
@@ -78,17 +78,17 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hashgraph/hedera-agent-kit": "workspace:*",
-        "@langchain/core": "1.1.24",
         "@langchain/mcp-adapters": "1.1.3",
         "@modelcontextprotocol/sdk": "1.27.1",
-        "langchain": "1.2.24",
         "zod": "3.25.76"
       },
       "devDependencies": {
         "@hashgraph/hedera-agent-kit-tests": "workspace:*",
         "@hiero-ledger/sdk": "2.81.0",
+        "@langchain/core": "1.1.24",
         "@langchain/openai": "1.2.7",
         "dotenv": "17.2.1",
+        "langchain": "1.2.24",
         "long": "5.3.2",
         "tsup": "8.5.0",
         "typescript": "5.8.3",
@@ -98,7 +98,9 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@hiero-ledger/sdk": "^2.81.0"
+        "@hiero-ledger/sdk": "^2.81.0",
+        "@langchain/core": "^1.1.24",
+        "langchain": "^1.2.24"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -78,6 +78,18 @@ console.log(parsed[0].toolName);   // e.g. "create_account_tool"
 console.log(parsed[0].parsedData); // tool execution result
 ```
 
+## Streaming
+
+When streaming with `agent.streamEvents({ version: 'v2' })`, the `on_tool_start` event's `name` is the shared wrapper class (`HederaAgentKitTool`). To label steps with the real tool name, read it from `event.metadata.hakToolName`:
+
+```typescript
+for await (const event of agent.streamEvents({ messages }, { version: 'v2' })) {
+  if (event.event === 'on_tool_start') {
+    console.log(event.metadata?.hakToolName); // e.g. "transfer_hbar_tool"
+  }
+}
+```
+
 ## MCP server support
 
 The toolkit can also load tools from external MCP servers:

--- a/packages/langchain/src/tool.ts
+++ b/packages/langchain/src/tool.ts
@@ -32,6 +32,10 @@ class HederaAgentKitTool extends StructuredTool {
     this.description = description;
     this.schema = schema;
     this.responseParsingFunction = responseParsingFunction;
+
+    // Surface the real tool name to stream events as `event.metadata.hakToolName`
+    // (on `on_tool_start`, event.name is the shared wrapper class). See README.
+    this.metadata = { ...this.metadata, hakToolName: method };
   }
 
   _call(


### PR DESCRIPTION
**Description**:
`on_tool_start.event.name` reports the wrapper class `HederaAgentKitTool` 
this adds the real name at step start as `event.metadata.hakToolName`. 

**Related issue(s)**:

Related to #837 