### PR TITLE
fix(mirrornode): retry transaction-record 404s with backoff

### DIFF
--- a/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
+++ b/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
@@ -31,17 +31,39 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
     this.baseUrl = LedgerIdToBaseUrl.get(ledgerId.toString())!;
   }
 
+  /**
+   * Fetches JSON from the mirror node, retrying only on 404 with exponential
+   * backoff. A just-created entity (transaction, token, topic, ...) is not
+   * indexed for a few seconds and returns 404, so a read fired right after the
+   * write would otherwise fail. Non-404 statuses throw immediately; an
+   * exhausted 404 throws via `buildError`.
+   */
+  private async fetchJson<T>(url: string, buildError: (response: Response) => string): Promise<T> {
+    const maxAttempts = 3;
+    let delayMs = 1000;
+    for (let attempt = 1; ; attempt++) {
+      const response = await fetch(url);
+
+      if (response.ok) {
+        return (await response.json()) as T;
+      }
+
+      if (response.status === 404 && attempt < maxAttempts) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        delayMs *= 2;
+        continue;
+      }
+
+      throw new Error(buildError(response));
+    }
+  }
+
   async getAccount(accountId: string): Promise<AccountResponse> {
     const url = `${this.baseUrl}/accounts/${accountId}`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch account ${accountId}: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const data: AccountAPIResponse = await response.json();
+    const data = await this.fetchJson<AccountAPIResponse>(
+      url,
+      r => `Failed to fetch account ${accountId}: ${r.status} ${r.statusText}`,
+    );
 
     // Check if the response is empty (no account found)
     if (!data.account) {
@@ -77,15 +99,10 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
   ): Promise<TokenBalancesResponse> {
     const tokenIdParam = tokenId ? `&token.id=${tokenId}` : '';
     const url = `${this.baseUrl}/accounts/${accountId}/tokens?${tokenIdParam}`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch balance for account ${accountId}: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const res = await response.json();
+    const res = await this.fetchJson<any>(
+      url,
+      r => `Failed to fetch balance for account ${accountId}: ${r.status} ${r.statusText}`,
+    );
 
     // Fetch and attach symbols in parallel
     await Promise.all(
@@ -120,15 +137,10 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
         // Results are paginated
 
         fetchedMessages += 1;
-        const response = await fetch(url);
-
-        if (!response.ok) {
-          throw new Error(
-            `Failed to get topic messages for ${queryParams.topicId}: ${response.status} ${response.statusText}`,
-          );
-        }
-
-        const data: TopicMessagesAPIResponse = await response.json();
+        const data: TopicMessagesAPIResponse = await this.fetchJson<TopicMessagesAPIResponse>(
+          url,
+          r => `Failed to get topic messages for ${queryParams.topicId}: ${r.status} ${r.statusText}`,
+        );
 
         arrayOfMessages.push(...data.messages);
         if (fetchedMessages >= 100) {
@@ -151,28 +163,18 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
 
   async getTokenInfo(tokenId: string): Promise<TokenInfo> {
     const url = `${this.baseUrl}/tokens/${tokenId}`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to get token info for a token ${tokenId}: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    return await response.json();
+    return this.fetchJson<TokenInfo>(
+      url,
+      r => `Failed to get token info for a token ${tokenId}: ${r.status} ${r.statusText}`,
+    );
   }
 
   async getTopicInfo(topicId: string): Promise<TopicInfo> {
     const url = `${this.baseUrl}/topics/${topicId}`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to get topic info for ${topicId}: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    return await response.json();
+    return this.fetchJson<TopicInfo>(
+      url,
+      r => `Failed to get topic info for ${topicId}: ${r.status} ${r.statusText}`,
+    );
   }
 
   async getTransactionRecord(
@@ -183,75 +185,44 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
     if (nonce !== undefined) {
       url += `?nonce=${nonce}`;
     }
-
-    const maxAttempts = 3;
-    let delayMs = 1000;
-    for (let attempt = 1; ; attempt++) {
-      const response = await fetch(url);
-
-      if (response.ok) {
-        return await response.json();
-      }
-
-      if (response.status === 404 && attempt < maxAttempts) {
-        await new Promise(resolve => setTimeout(resolve, delayMs));
-        delayMs *= 2;
-        continue;
-      }
-
-      throw new Error(
-        `Failed to get transaction record for ${transactionId}: ${response.status} ${response.statusText}`,
-      );
-    }
+    return this.fetchJson<TransactionDetailsResponse>(
+      url,
+      r => `Failed to get transaction record for ${transactionId}: ${r.status} ${r.statusText}`,
+    );
   }
 
   async getContractInfo(contractId: string): Promise<ContractInfo> {
     const url = `${this.baseUrl}/contracts/${contractId}`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to get contract info for ${contractId}: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    return await response.json();
+    return this.fetchJson<ContractInfo>(
+      url,
+      r => `Failed to get contract info for ${contractId}: ${r.status} ${r.statusText}`,
+    );
   }
 
   async getPendingAirdrops(accountId: string): Promise<TokenAirdropsResponse> {
     const url = `${this.baseUrl}/accounts/${accountId}/airdrops/pending`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch pending airdrops for an account ${accountId}: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    return await response.json();
+    return this.fetchJson<TokenAirdropsResponse>(
+      url,
+      r => `Failed to fetch pending airdrops for an account ${accountId}: ${r.status} ${r.statusText}`,
+    );
   }
 
   async getOutstandingAirdrops(accountId: string): Promise<TokenAirdropsResponse> {
     const url = `${this.baseUrl}/accounts/${accountId}/airdrops/outstanding`;
-    const response = await fetch(url);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch outstanding airdrops for an account ${accountId}: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    return await response.json();
+    return this.fetchJson<TokenAirdropsResponse>(
+      url,
+      r =>
+        `Failed to fetch outstanding airdrops for an account ${accountId}: ${r.status} ${r.statusText}`,
+    );
   }
 
   async getExchangeRate(timestamp?: string): Promise<ExchangeRateResponse> {
     const timestampParam = timestamp ? `?timestamp=${encodeURIComponent(timestamp)}` : '';
     const url = `${this.baseUrl}/network/exchangerate${timestampParam}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}. Message: ${response.statusText}`);
-    }
-    return await response.json();
+    return this.fetchJson<ExchangeRateResponse>(
+      url,
+      r => `HTTP error! status: ${r.status}. Message: ${r.statusText}`,
+    );
   }
 
   async getTokenAllowances(
@@ -259,31 +230,28 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
     spenderAccountId: string,
   ): Promise<TokenAllowanceResponse> {
     const url = `${this.baseUrl}/accounts/${ownerAccountId}/allowances/tokens?spender.id=${spenderAccountId}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}. Message: ${response.statusText}`);
-    }
-    return await response.json();
+    return this.fetchJson<TokenAllowanceResponse>(
+      url,
+      r => `HTTP error! status: ${r.status}. Message: ${r.statusText}`,
+    );
   }
 
   async getAccountNfts(ownerAccountId: string): Promise<NftBalanceResponse> {
     const url = `${this.baseUrl}/accounts/${ownerAccountId}/nfts`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}. Message: ${response.statusText}`);
-    }
-    return await response.json();
+    return this.fetchJson<NftBalanceResponse>(
+      url,
+      r => `HTTP error! status: ${r.status}. Message: ${r.statusText}`,
+    );
   }
 
   async getScheduledTransactionDetails(
     scheduleId: string,
   ): Promise<ScheduledTransactionDetailsResponse> {
     const url = `${this.baseUrl}/schedules/${scheduleId}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}. Message: ${response.statusText}`);
-    }
-    return await response.json();
+    return this.fetchJson<ScheduledTransactionDetailsResponse>(
+      url,
+      r => `HTTP error! status: ${r.status}. Message: ${r.statusText}`,
+    );
   }
 
   getBaseUrl(): string {

--- a/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
+++ b/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
@@ -184,15 +184,25 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
       url += `?nonce=${nonce}`;
     }
 
-    const response = await fetch(url);
+    const maxAttempts = 3;
+    let delayMs = 1000;
+    for (let attempt = 1; ; attempt++) {
+      const response = await fetch(url);
 
-    if (!response.ok) {
+      if (response.ok) {
+        return await response.json();
+      }
+
+      if (response.status === 404 && attempt < maxAttempts) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        delayMs *= 2;
+        continue;
+      }
+
       throw new Error(
         `Failed to get transaction record for ${transactionId}: ${response.status} ${response.statusText}`,
       );
     }
-
-    return await response.json();
   }
 
   async getContractInfo(contractId: string): Promise<ContractInfo> {

--- a/packages/core/tests/unit/mirrornode/get-transaction-record-retry.unit.test.ts
+++ b/packages/core/tests/unit/mirrornode/get-transaction-record-retry.unit.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LedgerId } from '@hiero-ledger/sdk';
+import { HederaMirrornodeServiceDefaultImpl } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl';
+
+const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+const notFound = () => ({ ok: false, status: 404, statusText: 'Not Found' });
+const serverError = () => ({ ok: false, status: 500, statusText: 'Internal Server Error' });
+
+describe('mirror node getTransactionRecord - 404 retry with backoff', () => {
+  const service = new HederaMirrornodeServiceDefaultImpl(LedgerId.TESTNET);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries a fresh-transaction 404 and resolves once indexed', async () => {
+    const record = { transactions: [{ result: 'SUCCESS' }] };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(notFound()) // not indexed yet
+      .mockResolvedValueOnce(notFound()) // still not indexed
+      .mockResolvedValueOnce(ok(record)); // indexed
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = service.getTransactionRecord('0.0.1-1-1');
+    await vi.runAllTimersAsync(); // fast-forward the backoff waits
+
+    await expect(promise).resolves.toEqual(record);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws after exhausting retries when it stays 404', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(notFound());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = service.getTransactionRecord('0.0.9-9-9');
+    const assertion = expect(promise).rejects.toThrow('404 Not Found');
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3); // maxAttempts
+  });
+
+  it('does not retry non-404 errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(serverError());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(service.getTransactionRecord('0.0.2-2-2')).rejects.toThrow('500');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/tests/unit/mirrornode/get-transaction-record-retry.unit.test.ts
+++ b/packages/core/tests/unit/mirrornode/get-transaction-record-retry.unit.test.ts
@@ -52,4 +52,19 @@ describe('mirror node getTransactionRecord - 404 retry with backoff', () => {
     await expect(service.getTransactionRecord('0.0.2-2-2')).rejects.toThrow('500');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('applies the same 404 retry to other methods (getTokenInfo)', async () => {
+    const info = { token_id: '0.0.5', symbol: 'FOO' };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(notFound()) // token not indexed yet after creation
+      .mockResolvedValueOnce(ok(info));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = service.getTokenInfo('0.0.5');
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toEqual(info);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
**Description**:
A freshly submitted transaction is not indexed by the mirror node for a few seconds and returns 404, so the transfer -> verify-record handoff failed. Retry 404s up to 3 attempts with exponential backoff (1s, 2s). Non-404 errors and an exhausted 404 throw as before.

**Related issue(s)**:

Fixes #857