### PR TITLE
feat: typed tool result status

### DIFF
--- a/docs/MIGRATION-v4.md
+++ b/docs/MIGRATION-v4.md
@@ -746,7 +746,7 @@ export class TransferHbarTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[transfer_hbar_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/adk/src/tool.ts
+++ b/packages/adk/src/tool.ts
@@ -2,21 +2,21 @@ import { HederaAgentAPI } from '@hashgraph/hedera-agent-kit';
 import { FunctionTool, type ToolInputParameters } from '@google/adk';
 
 export default function HederaAgentKitTool(
-    hederaAPI: HederaAgentAPI,
-    method: string,
-    description: string,
-    schema: ToolInputParameters,
+  hederaAPI: HederaAgentAPI,
+  method: string,
+  description: string,
+  schema: ToolInputParameters,
 ): FunctionTool {
-    // ADK format enforces a strict regex for tool names: ^[a-zA-Z0-9_-]+$
-    // In case plugins have special characters like spaces or brackets, replace with _
-    const sanitizedMethodName = method.replace(/[^a-zA-Z0-9_-]/g, '_');
+  // ADK format enforces a strict regex for tool names: ^[a-zA-Z0-9_-]+$
+  // In case plugins have special characters like spaces or brackets, replace with _
+  const sanitizedMethodName = method.replace(/[^a-zA-Z0-9_-]/g, '_');
 
-    return new FunctionTool({
-        name: sanitizedMethodName,
-        description: description,
-        parameters: schema,
-        execute: async (arg: ThisParameterType<typeof schema>) => {
-            return JSON.parse(await hederaAPI.run(method, arg));
-        },
-    });
+  return new FunctionTool({
+    name: sanitizedMethodName,
+    description: description,
+    parameters: schema,
+    execute: async (arg: ThisParameterType<typeof schema>) => {
+      return JSON.parse(await hederaAPI.run(method, arg));
+    },
+  });
 }

--- a/packages/adk/src/toolkit.ts
+++ b/packages/adk/src/toolkit.ts
@@ -1,35 +1,40 @@
-import { HederaAgentAPI, Configuration, ToolDiscovery, type Tool } from '@hashgraph/hedera-agent-kit';
+import {
+  HederaAgentAPI,
+  Configuration,
+  ToolDiscovery,
+  type Tool,
+} from '@hashgraph/hedera-agent-kit';
 import { Client } from '@hiero-ledger/sdk';
 import HederaAgentKitTool from './tool';
 import type { BaseTool, ToolInputParameters } from '@google/adk';
 
 class HederaADKToolkit {
-    private hedera: HederaAgentAPI;
-    private configuration: Configuration;
+  private hedera: HederaAgentAPI;
+  private configuration: Configuration;
 
-    tools: { [key: string]: BaseTool };
+  tools: { [key: string]: BaseTool };
 
-    constructor({ client, configuration }: { client: Client; configuration: Configuration }) {
-        this.configuration = configuration;
-        const context = configuration.context || {};
-        const toolDiscovery = ToolDiscovery.createFromConfiguration(configuration);
-        const allTools = toolDiscovery.getAllTools(context, configuration);
-        this.hedera = new HederaAgentAPI(client, configuration.context, allTools);
-        this.tools = {};
+  constructor({ client, configuration }: { client: Client; configuration: Configuration }) {
+    this.configuration = configuration;
+    const context = configuration.context || {};
+    const toolDiscovery = ToolDiscovery.createFromConfiguration(configuration);
+    const allTools = toolDiscovery.getAllTools(context, configuration);
+    this.hedera = new HederaAgentAPI(client, configuration.context, allTools);
+    this.tools = {};
 
-        allTools.forEach((tool: Tool) => {
-            this.tools[tool.method] = HederaAgentKitTool(
-                this.hedera,
-                tool.method,
-                tool.description,
-                tool.parameters as unknown as ToolInputParameters,
-            );
-        });
-    }
+    allTools.forEach((tool: Tool) => {
+      this.tools[tool.method] = HederaAgentKitTool(
+        this.hedera,
+        tool.method,
+        tool.description,
+        tool.parameters as unknown as ToolInputParameters,
+      );
+    });
+  }
 
-    getTools(): BaseTool[] {
-        return Object.values(this.tools);
-    }
+  getTools(): BaseTool[] {
+    return Object.values(this.tools);
+  }
 }
 
 export default HederaADKToolkit;

--- a/packages/core/src/hooks/hol-audit-trail-hook/audit/audit-entry.ts
+++ b/packages/core/src/hooks/hol-audit-trail-hook/audit/audit-entry.ts
@@ -1,6 +1,10 @@
 import z from 'zod';
 
-import { HOL_AUDIT_ENTRY_TYPE, HOL_AUDIT_ENTRY_VERSION, HOL_AUDIT_ENTRY_SOURCE } from '@/hooks/hol-audit-trail-hook/audit/constants';
+import {
+  HOL_AUDIT_ENTRY_TYPE,
+  HOL_AUDIT_ENTRY_VERSION,
+  HOL_AUDIT_ENTRY_SOURCE,
+} from '@/hooks/hol-audit-trail-hook/audit/constants';
 
 export type AuditEntry = {
   type: typeof HOL_AUDIT_ENTRY_TYPE;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export type { Plugin } from './shared/plugin';
 export { PluginRegistry } from './shared/plugin';
 export { BaseTool } from './shared/tools';
 export type { Tool } from './shared/tools';
+export { BaseTransactionTool } from './shared/base-transaction-tool';
 export { ToolDiscovery } from './shared/tool-discovery';
 export { default as HederaBuilder } from './shared/hedera-utils/hedera-builder';
 export { AbstractPolicy } from './shared/policy';
@@ -34,7 +35,7 @@ export {
   untypedQueryOutputParser,
   classifyToolResult,
 } from './shared/utils/default-tool-output-parsing';
-export type { ToolResultStatus } from './shared/utils/default-tool-output-parsing';
+export type { ToolResultStatus, ToolRawStatus } from './shared/utils/default-tool-output-parsing';
 export { IHederaMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface';
 export { getMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
 export { HederaMirrornodeServiceDefaultImpl } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,9 @@ export { PromptGenerator } from './shared/utils/prompt-generator';
 export {
   transactionToolOutputParser,
   untypedQueryOutputParser,
+  classifyToolResult,
 } from './shared/utils/default-tool-output-parsing';
+export type { ToolResultStatus } from './shared/utils/default-tool-output-parsing';
 export { IHederaMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface';
 export { getMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
 export { HederaMirrornodeServiceDefaultImpl } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,7 @@ export type { ToolResultStatus, ToolRawStatus } from './shared/utils/default-too
 export { IHederaMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface';
 export { getMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
 export { HederaMirrornodeServiceDefaultImpl } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl';
-export { toBaseUnit, toDisplayUnit } from './shared/hedera-utils/decimals-utils';
+export { toBaseUnit, toDisplayUnit, getERC20Decimals } from './shared/hedera-utils/decimals-utils';
 export { toHbar } from './shared/hedera-utils/hbar-conversion-utils';
 export type { TransferHbarInput, TokenTransferMinimalParams } from './shared/hedera-utils/types';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export {
   transactionToolOutputParser,
   untypedQueryOutputParser,
   classifyToolResult,
+  TOOL_STATUS,
 } from './shared/utils/default-tool-output-parsing';
 export type { ToolResultStatus, ToolRawStatus } from './shared/utils/default-tool-output-parsing';
 export { IHederaMirrornodeService } from './shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/approve-hbar-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/approve-hbar-allowance.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -40,7 +40,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const APPROVE_HBAR_ALLOWANCE_TOOL = 'approve_hbar_allowance_tool';
 
-export class ApproveHbarAllowanceTool extends BaseTool {
+export class ApproveHbarAllowanceTool extends BaseTransactionTool {
   method = APPROVE_HBAR_ALLOWANCE_TOOL;
   name = 'Approve HBAR Allowance';
   description: string;
@@ -68,18 +68,8 @@ export class ApproveHbarAllowanceTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to approve hbar allowance.';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[approve_hbar_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new ApproveHbarAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new ApproveHbarAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/approve-hbar-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/approve-hbar-allowance.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { approveHbarAllowanceParameters } from '@/shared/parameter-schemas/account.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/approve-hbar-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/approve-hbar-allowance.ts
@@ -74,7 +74,7 @@ export class ApproveHbarAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[approve_hbar_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-plugin/tools/account/create-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/create-account.ts
@@ -89,7 +89,7 @@ export class CreateAccountTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[create_account_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-plugin/tools/account/create-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/create-account.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { createAccountParameters } from '@/shared/parameter-schemas/account.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/create-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/create-account.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -49,7 +49,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const CREATE_ACCOUNT_TOOL = 'create_account_tool';
 
-export class CreateAccountTool extends BaseTool {
+export class CreateAccountTool extends BaseTransactionTool {
   method = CREATE_ACCOUNT_TOOL;
   name = 'Create Account';
   description: string;
@@ -83,18 +83,8 @@ export class CreateAccountTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to create account';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[create_account_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new CreateAccountTool(context);
+const tool = (context: Context): BaseTransactionTool => new CreateAccountTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/delete-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/delete-account.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -36,7 +36,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const DELETE_ACCOUNT_TOOL = 'delete_account_tool';
 
-export class DeleteAccountTool extends BaseTool {
+export class DeleteAccountTool extends BaseTransactionTool {
   method = DELETE_ACCOUNT_TOOL;
   name = 'Delete Account';
   description: string;
@@ -64,18 +64,8 @@ export class DeleteAccountTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to delete account';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[delete_account_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new DeleteAccountTool(context);
+const tool = (context: Context): BaseTransactionTool => new DeleteAccountTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/delete-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/delete-account.ts
@@ -70,7 +70,7 @@ export class DeleteAccountTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[delete_account_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-plugin/tools/account/delete-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/delete-account.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import { deleteAccountParameters } from '@/shared/parameter-schemas/account.zod';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/delete-hbar-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/delete-hbar-allowance.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { deleteHbarAllowanceParameters } from '@/shared/parameter-schemas/account.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/delete-hbar-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/delete-hbar-allowance.ts
@@ -77,7 +77,7 @@ export class DeleteHbarAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[delete_hbar_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-plugin/tools/account/delete-hbar-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/delete-hbar-allowance.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -42,7 +42,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const DELETE_HBAR_ALLOWANCE_TOOL = 'delete_hbar_allowance_tool';
 
-export class DeleteHbarAllowanceTool extends BaseTool {
+export class DeleteHbarAllowanceTool extends BaseTransactionTool {
   method = DELETE_HBAR_ALLOWANCE_TOOL;
   name = 'Delete HBAR Allowance';
   description: string;
@@ -71,18 +71,8 @@ export class DeleteHbarAllowanceTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to delete hbar allowance.';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[delete_hbar_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new DeleteHbarAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new DeleteHbarAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/schedule-delete.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/schedule-delete.ts
@@ -66,7 +66,7 @@ export class ScheduleDeleteTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[schedule_delete_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-plugin/tools/account/schedule-delete.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/schedule-delete.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -32,7 +32,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const SCHEDULE_DELETE_TOOL = 'schedule_delete_tool';
 
-export class ScheduleDeleteTool extends BaseTool {
+export class ScheduleDeleteTool extends BaseTransactionTool {
   method = SCHEDULE_DELETE_TOOL;
   name = 'Delete Scheduled Transaction';
   description: string;
@@ -60,18 +60,8 @@ export class ScheduleDeleteTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to delete scheduled transaction';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[schedule_delete_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new ScheduleDeleteTool(context);
+const tool = (context: Context): BaseTransactionTool => new ScheduleDeleteTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/schedule-delete.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/schedule-delete.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { scheduleDeleteTransactionParameters } from '@/shared/parameter-schemas/account.zod';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/sign-schedule-transaction.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/sign-schedule-transaction.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -32,7 +32,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const SIGN_SCHEDULE_TRANSACTION_TOOL = 'sign_schedule_transaction_tool';
 
-export class SignScheduleTransactionTool extends BaseTool {
+export class SignScheduleTransactionTool extends BaseTransactionTool {
   method = SIGN_SCHEDULE_TRANSACTION_TOOL;
   name = 'Sign Scheduled Transaction';
   description: string;
@@ -60,18 +60,8 @@ export class SignScheduleTransactionTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to sign scheduled transaction';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[sign_schedule_transaction_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new SignScheduleTransactionTool(context);
+const tool = (context: Context): BaseTransactionTool => new SignScheduleTransactionTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/sign-schedule-transaction.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/sign-schedule-transaction.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { signScheduleTransactionParameters } from '@/shared/parameter-schemas/account.zod';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/sign-schedule-transaction.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/sign-schedule-transaction.ts
@@ -66,7 +66,7 @@ export class SignScheduleTransactionTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[sign_schedule_transaction_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar-with-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar-with-allowance.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { transferHbarWithAllowanceParameters } from '@/shared/parameter-schemas/account.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar-with-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar-with-allowance.ts
@@ -71,7 +71,7 @@ export class TransferHbarWithAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[transfer_hbar_with_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar-with-allowance.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar-with-allowance.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -37,7 +37,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const TRANSFER_HBAR_WITH_ALLOWANCE_TOOL = 'transfer_hbar_with_allowance_tool';
 
-export class TransferHbarWithAllowanceTool extends BaseTool {
+export class TransferHbarWithAllowanceTool extends BaseTransactionTool {
   method = TRANSFER_HBAR_WITH_ALLOWANCE_TOOL;
   name = 'Transfer HBAR with allowance';
   description: string;
@@ -65,18 +65,8 @@ export class TransferHbarWithAllowanceTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to transfer HBAR with allowance';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[transfer_hbar_with_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new TransferHbarWithAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new TransferHbarWithAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar.ts
@@ -83,7 +83,7 @@ export class TransferHbarTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[transfer_hbar_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { transferHbarParameters } from '@/shared/parameter-schemas/account.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/transfer-hbar.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -49,7 +49,7 @@ Transaction ID: ${response.transactionId}`;
 
 export const TRANSFER_HBAR_TOOL = 'transfer_hbar_tool';
 
-export class TransferHbarTool extends BaseTool {
+export class TransferHbarTool extends BaseTransactionTool {
   method = TRANSFER_HBAR_TOOL;
   name = 'Transfer HBAR';
   description: string;
@@ -77,18 +77,8 @@ export class TransferHbarTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to transfer HBAR';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[transfer_hbar_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new TransferHbarTool(context);
+const tool = (context: Context): BaseTransactionTool => new TransferHbarTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/update-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/update-account.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -47,7 +47,7 @@ Transaction ID: ${response.transactionId}`;
 
 export const UPDATE_ACCOUNT_TOOL = 'update_account_tool';
 
-export class UpdateAccountTool extends BaseTool {
+export class UpdateAccountTool extends BaseTransactionTool {
   method = UPDATE_ACCOUNT_TOOL;
   name = 'Update Account';
   description: string;
@@ -75,18 +75,8 @@ export class UpdateAccountTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to update account';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[update_account_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new UpdateAccountTool(context);
+const tool = (context: Context): BaseTransactionTool => new UpdateAccountTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-account-plugin/tools/account/update-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/update-account.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-account-plugin/tools/account/update-account.ts
+++ b/packages/core/src/plugins/core-account-plugin/tools/account/update-account.ts
@@ -81,7 +81,7 @@ export class UpdateAccountTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[update_account_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-account-query.ts
+++ b/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-account-query.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import BigNumber from 'bignumber.js';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { Context } from '@/shared/configuration';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
 import { BaseTool } from '@/shared/tools';
@@ -74,7 +74,7 @@ export class GetAccountQueryTool extends BaseTool {
       hbarBalance,
     };
     return {
-      raw: { accountId: normalisedParams.accountId, account: accountWithHbar },
+      raw: { accountId: normalisedParams.accountId, account: accountWithHbar, status: 'SUCCESS' },
       humanMessage: postProcess(accountWithHbar),
     };
   }
@@ -93,7 +93,7 @@ export class GetAccountQueryTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_account_query_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-account-query.ts
+++ b/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-account-query.ts
@@ -74,7 +74,7 @@ export class GetAccountQueryTool extends BaseTool {
       hbarBalance,
     };
     return {
-      raw: { accountId: normalisedParams.accountId, account: accountWithHbar, status: 'SUCCESS' },
+      raw: { accountId: normalisedParams.accountId, account: accountWithHbar },
       humanMessage: postProcess(accountWithHbar),
     };
   }
@@ -86,16 +86,6 @@ export class GetAccountQueryTool extends BaseTool {
   async secondaryAction(_request: any, _client: Client, _context: Context): Promise<any> {
     // No secondary action for queries
     return null;
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get account query';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_account_query_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
   }
 }
 

--- a/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-account-token-balances-query.ts
+++ b/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-account-token-balances-query.ts
@@ -79,7 +79,6 @@ export class GetAccountTokenBalancesQueryTool extends BaseTool {
       raw: {
         accountId: normalisedParams.accountId,
         tokenBalances: tokenBalances,
-        status: 'SUCCESS',
       },
       humanMessage: postProcess(tokenBalances, normalisedParams.accountId),
     };
@@ -91,13 +90,6 @@ export class GetAccountTokenBalancesQueryTool extends BaseTool {
 
   async secondaryAction(_request: any, _client: Client, _context: Context): Promise<any> {
     return null;
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get account token balances';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_account_token_balances_query_tool]', message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-account-token-balances-query.ts
+++ b/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-account-token-balances-query.ts
@@ -79,6 +79,7 @@ export class GetAccountTokenBalancesQueryTool extends BaseTool {
       raw: {
         accountId: normalisedParams.accountId,
         tokenBalances: tokenBalances,
+        status: 'SUCCESS',
       },
       humanMessage: postProcess(tokenBalances, normalisedParams.accountId),
     };
@@ -96,7 +97,7 @@ export class GetAccountTokenBalancesQueryTool extends BaseTool {
     const desc = 'Failed to get account token balances';
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_account_token_balances_query_tool]', message);
-    return { raw: { error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-hbar-balance-query.ts
+++ b/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-hbar-balance-query.ts
@@ -59,7 +59,7 @@ export class GetHbarBalanceQueryTool extends BaseTool {
       normalisedParams.accountId,
     );
     return {
-      raw: { accountId: normalisedParams.accountId, hbarBalance: toHbar(balance).toString() },
+      raw: { accountId: normalisedParams.accountId, hbarBalance: toHbar(balance).toString(), status: 'SUCCESS' },
       humanMessage: postProcess(toHbar(balance).toString() as string, normalisedParams.accountId),
     };
   }
@@ -76,7 +76,7 @@ export class GetHbarBalanceQueryTool extends BaseTool {
     const desc = 'Failed to get HBAR balance';
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_hbar_balance_query_tool]', message);
-    return { raw: { error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-hbar-balance-query.ts
+++ b/packages/core/src/plugins/core-account-query-plugin/tools/queries/get-hbar-balance-query.ts
@@ -59,7 +59,7 @@ export class GetHbarBalanceQueryTool extends BaseTool {
       normalisedParams.accountId,
     );
     return {
-      raw: { accountId: normalisedParams.accountId, hbarBalance: toHbar(balance).toString(), status: 'SUCCESS' },
+      raw: { accountId: normalisedParams.accountId, hbarBalance: toHbar(balance).toString() },
       humanMessage: postProcess(toHbar(balance).toString() as string, normalisedParams.accountId),
     };
   }
@@ -70,13 +70,6 @@ export class GetHbarBalanceQueryTool extends BaseTool {
 
   async secondaryAction(request: any, _client: Client, _context: Context) {
     return request;
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get HBAR balance';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_hbar_balance_query_tool]', message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/create-topic.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/create-topic.ts
@@ -77,7 +77,7 @@ export class CreateTopicTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[create_topic_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/create-topic.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/create-topic.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { createTopicParameters } from '@/shared/parameter-schemas/consensus.zod';
@@ -34,7 +34,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const CREATE_TOPIC_TOOL = 'create_topic_tool';
 
-export class CreateTopicTool extends BaseTool {
+export class CreateTopicTool extends BaseTransactionTool {
   method = CREATE_TOPIC_TOOL;
   name = 'Create Topic';
   description: string;
@@ -71,18 +71,8 @@ export class CreateTopicTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to create topic';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[create_topic_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new CreateTopicTool(context);
+const tool = (context: Context): BaseTransactionTool => new CreateTopicTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/delete-topic.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/delete-topic.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/delete-topic.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/delete-topic.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -32,7 +32,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const DELETE_TOPIC_TOOL = 'delete_topic_tool';
 
-export class DeleteTopicTool extends BaseTool {
+export class DeleteTopicTool extends BaseTransactionTool {
   method = DELETE_TOPIC_TOOL;
   name = 'Delete Topic';
   description: string;
@@ -69,18 +69,8 @@ export class DeleteTopicTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to delete the topic';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[delete_topic_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new DeleteTopicTool(context);
+const tool = (context: Context): BaseTransactionTool => new DeleteTopicTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/delete-topic.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/delete-topic.ts
@@ -75,7 +75,7 @@ export class DeleteTopicTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[delete_topic_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/submit-topic-message.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/submit-topic-message.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { submitTopicMessageParameters } from '@/shared/parameter-schemas/consensus.zod';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/submit-topic-message.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/submit-topic-message.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -33,7 +33,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const SUBMIT_TOPIC_MESSAGE_TOOL = 'submit_topic_message_tool';
 
-export class SubmitTopicMessageTool extends BaseTool {
+export class SubmitTopicMessageTool extends BaseTransactionTool {
   method = SUBMIT_TOPIC_MESSAGE_TOOL;
   name = 'Submit Topic Message';
   description: string;
@@ -61,18 +61,8 @@ export class SubmitTopicMessageTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to submit message to topic';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[submit_topic_message_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new SubmitTopicMessageTool(context);
+const tool = (context: Context): BaseTransactionTool => new SubmitTopicMessageTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/submit-topic-message.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/submit-topic-message.ts
@@ -67,7 +67,7 @@ export class SubmitTopicMessageTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[submit_topic_message_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/update-topic.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/update-topic.ts
@@ -138,7 +138,7 @@ export class UpdateTopicTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[update_topic_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/update-topic.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/update-topic.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, PublicKey, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client, PublicKey } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -99,7 +99,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const UPDATE_TOPIC_TOOL = 'update_topic_tool';
 
-export class UpdateTopicTool extends BaseTool {
+export class UpdateTopicTool extends BaseTransactionTool {
   method = UPDATE_TOPIC_TOOL;
   name = 'Update Topic';
   description: string;
@@ -132,18 +132,8 @@ export class UpdateTopicTool extends BaseTool {
   async secondaryAction(transaction: any, client: Client, context: Context) {
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to update topic';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[update_topic_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new UpdateTopicTool(context);
+const tool = (context: Context): BaseTransactionTool => new UpdateTopicTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-consensus-plugin/tools/consensus/update-topic.ts
+++ b/packages/core/src/plugins/core-consensus-plugin/tools/consensus/update-topic.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client, PublicKey } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-consensus-query-plugin/tools/queries/get-topic-info-query.ts
+++ b/packages/core/src/plugins/core-consensus-query-plugin/tools/queries/get-topic-info-query.ts
@@ -90,7 +90,7 @@ export class GetTopicInfoQueryTool extends BaseTool {
     };
 
     return {
-      raw: { topicId: normalisedParams.topicId, topicInfo },
+      raw: { topicId: normalisedParams.topicId, topicInfo, status: 'SUCCESS' },
       humanMessage: postProcess(topicInfo),
     };
   }
@@ -107,7 +107,7 @@ export class GetTopicInfoQueryTool extends BaseTool {
     const desc = 'Failed to get topic info';
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_topic_info_query_tool]', message);
-    return { raw: { error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-consensus-query-plugin/tools/queries/get-topic-info-query.ts
+++ b/packages/core/src/plugins/core-consensus-query-plugin/tools/queries/get-topic-info-query.ts
@@ -90,7 +90,7 @@ export class GetTopicInfoQueryTool extends BaseTool {
     };
 
     return {
-      raw: { topicId: normalisedParams.topicId, topicInfo, status: 'SUCCESS' },
+      raw: { topicId: normalisedParams.topicId, topicInfo },
       humanMessage: postProcess(topicInfo),
     };
   }
@@ -101,13 +101,6 @@ export class GetTopicInfoQueryTool extends BaseTool {
 
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null; // Not applicable for query tools
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get topic info';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_topic_info_query_tool]', message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-consensus-query-plugin/tools/queries/get-topic-messages-query.ts
+++ b/packages/core/src/plugins/core-consensus-query-plugin/tools/queries/get-topic-messages-query.ts
@@ -4,10 +4,7 @@ import { topicMessagesQueryParameters } from '@/shared/parameter-schemas/consens
 import { Client } from '@hiero-ledger/sdk';
 import { z } from 'zod';
 import { BaseTool } from '@/shared/tools';
-import {
-  TopicMessage,
-  TopicMessagesQueryParams,
-} from '@/shared/hedera-utils/mirrornode/types';
+import { TopicMessage, TopicMessagesQueryParams } from '@/shared/hedera-utils/mirrornode/types';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import { untypedQueryOutputParser } from '@/shared/utils/default-tool-output-parsing';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -37,8 +34,7 @@ const postProcess = (messages: TopicMessage[], topicId: string) => {
   }
 
   const messagesText = messages.map(
-    message =>
-        `${base64ToUtf8(message.message)} - posted at: ${message.consensus_timestamp}\n`,
+    message => `${base64ToUtf8(message.message)} - posted at: ${message.consensus_timestamp}\n`,
   );
 
   return `Messages for topic ${topicId}:
@@ -108,7 +104,6 @@ export class GetTopicMessagesQueryTool extends BaseTool {
       raw: {
         topicId: messages.topicId,
         messages: convertMessagesFromBase64ToString(messages.messages),
-        status: 'SUCCESS',
       },
       humanMessage: postProcess(messages.messages, normalisedParams.topicId),
     };
@@ -120,13 +115,6 @@ export class GetTopicMessagesQueryTool extends BaseTool {
 
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null; // Not applicable for query tools
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get topic messages';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_topic_messages_query_tool]', message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-consensus-query-plugin/tools/queries/get-topic-messages-query.ts
+++ b/packages/core/src/plugins/core-consensus-query-plugin/tools/queries/get-topic-messages-query.ts
@@ -108,6 +108,7 @@ export class GetTopicMessagesQueryTool extends BaseTool {
       raw: {
         topicId: messages.topicId,
         messages: convertMessagesFromBase64ToString(messages.messages),
+        status: 'SUCCESS',
       },
       humanMessage: postProcess(messages.messages, normalisedParams.topicId),
     };
@@ -125,7 +126,7 @@ export class GetTopicMessagesQueryTool extends BaseTool {
     const desc = 'Failed to get topic messages';
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_topic_messages_query_tool]', message);
-    return { raw: { error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc20/create-erc20.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc20/create-erc20.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { AgentMode, type Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status, TransactionRecordQuery } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client, TransactionRecordQuery } from '@hiero-ledger/sdk';
 import {
   ExecuteStrategyResult,
   handleTransaction,
@@ -46,7 +46,7 @@ Schedule ID: ${response.scheduleId.toString()}`
 
 export const CREATE_ERC20_TOOL = 'create_erc20_tool';
 
-export class CreateErc20Tool extends BaseTool {
+export class CreateErc20Tool extends BaseTransactionTool {
   method = CREATE_ERC20_TOOL;
   name = 'Create ERC20 Token';
   description: string;
@@ -91,18 +91,8 @@ export class CreateErc20Tool extends BaseTool {
 
     return { ...result, erc20Address, humanMessage };
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const message =
-      'Failed to create ERC20 token' + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[create_erc20_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new CreateErc20Tool(context);
+const tool = (context: Context): BaseTransactionTool => new CreateErc20Tool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc20/create-erc20.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc20/create-erc20.ts
@@ -97,7 +97,7 @@ export class CreateErc20Tool extends BaseTool {
       'Failed to create ERC20 token' + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[create_erc20_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc20/transfer-erc20.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc20/transfer-erc20.ts
@@ -95,7 +95,7 @@ export class TransferErc20Tool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[transfer_erc20_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc20/transfer-erc20.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc20/transfer-erc20.ts
@@ -3,10 +3,7 @@ import { AgentMode, type Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { transferERC20Parameters } from '@/shared/parameter-schemas/evm.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc20/transfer-erc20.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc20/transfer-erc20.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { AgentMode, type Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -49,7 +49,7 @@ Schedule ID: ${response.scheduleId.toString()}`
 
 export const TRANSFER_ERC20_TOOL = 'transfer_erc20_tool';
 
-export class TransferErc20Tool extends BaseTool {
+export class TransferErc20Tool extends BaseTransactionTool {
   method = TRANSFER_ERC20_TOOL;
   name = 'Transfer ERC20';
   description: string;
@@ -89,18 +89,8 @@ export class TransferErc20Tool extends BaseTool {
     }
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to transfer ERC20';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[transfer_erc20_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new TransferErc20Tool(context);
+const tool = (context: Context): BaseTransactionTool => new TransferErc20Tool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/create-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/create-erc721.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { AgentMode, type Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status, TransactionRecordQuery } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client, TransactionRecordQuery } from '@hiero-ledger/sdk';
 import {
   ExecuteStrategyResult,
   handleTransaction,
@@ -49,7 +49,7 @@ Schedule ID: ${response.scheduleId.toString()}`
 
 export const CREATE_ERC721_TOOL = 'create_erc721_tool';
 
-export class CreateErc721Tool extends BaseTool {
+export class CreateErc721Tool extends BaseTransactionTool {
   method = CREATE_ERC721_TOOL;
   name = 'Create ERC721 Token';
   description: string;
@@ -94,18 +94,8 @@ export class CreateErc721Tool extends BaseTool {
 
     return { ...result, erc721Address, humanMessage };
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const message =
-      'Failed to create ERC721 token' + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[create_erc721_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new CreateErc721Tool(context);
+const tool = (context: Context): BaseTransactionTool => new CreateErc721Tool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/create-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/create-erc721.ts
@@ -11,10 +11,7 @@ import { createERC721Parameters } from '@/shared/parameter-schemas/evm.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import {
-  getERC721FactoryAddress,
-  ERC721_FACTORY_ABI,
-} from '@/shared/constants/contracts';
+import { getERC721FactoryAddress, ERC721_FACTORY_ABI } from '@/shared/constants/contracts';
 import { transactionToolOutputParser } from '@/shared/utils/default-tool-output-parsing';
 import { assertEcdsaOperator } from '@/plugins/core-evm-plugin/utils/operator-key';
 

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/create-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/create-erc721.ts
@@ -100,7 +100,7 @@ export class CreateErc721Tool extends BaseTool {
       'Failed to create ERC721 token' + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[create_erc721_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/mint-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/mint-erc721.ts
@@ -3,17 +3,11 @@ import { AgentMode, type Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
-import {
-  ERC721_MINT_FUNCTION_ABI,
-  ERC721_MINT_FUNCTION_NAME,
-} from '@/shared/constants/contracts';
+import { ERC721_MINT_FUNCTION_ABI, ERC721_MINT_FUNCTION_NAME } from '@/shared/constants/contracts';
 import { mintERC721Parameters } from '@/shared/parameter-schemas/evm.zod';
 import { transactionToolOutputParser } from '@/shared/utils/default-tool-output-parsing';
 import { assertEcdsaOperator } from '@/plugins/core-evm-plugin/utils/operator-key';

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/mint-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/mint-erc721.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { AgentMode, type Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -58,7 +58,7 @@ Schedule ID: ${response.scheduleId.toString()}`
 
 export const MINT_ERC721_TOOL = 'mint_erc721_tool';
 
-export class MintErc721Tool extends BaseTool {
+export class MintErc721Tool extends BaseTransactionTool {
   method = MINT_ERC721_TOOL;
   name = 'Mint ERC721';
   description: string;
@@ -98,18 +98,8 @@ export class MintErc721Tool extends BaseTool {
     }
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to mint ERC721';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[mint_erc721_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new MintErc721Tool(context);
+const tool = (context: Context): BaseTransactionTool => new MintErc721Tool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/mint-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/mint-erc721.ts
@@ -104,7 +104,7 @@ export class MintErc721Tool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[mint_erc721_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/transfer-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/transfer-erc721.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { AgentMode, type Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -55,7 +55,7 @@ Schedule ID: ${response.scheduleId.toString()}`
 
 export const TRANSFER_ERC721_TOOL = 'transfer_erc721_tool';
 
-export class TransferErc721Tool extends BaseTool {
+export class TransferErc721Tool extends BaseTransactionTool {
   method = TRANSFER_ERC721_TOOL;
   name = 'Transfer ERC721';
   description: string;
@@ -95,18 +95,8 @@ export class TransferErc721Tool extends BaseTool {
     }
     return await handleTransaction(transaction, client, context, postProcess);
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const message =
-      'Failed to transfer ERC721' + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[transfer_erc721_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new TransferErc721Tool(context);
+const tool = (context: Context): BaseTransactionTool => new TransferErc721Tool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/transfer-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/transfer-erc721.ts
@@ -3,10 +3,7 @@ import { AgentMode, type Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';

--- a/packages/core/src/plugins/core-evm-plugin/tools/erc721/transfer-erc721.ts
+++ b/packages/core/src/plugins/core-evm-plugin/tools/erc721/transfer-erc721.ts
@@ -101,7 +101,7 @@ export class TransferErc721Tool extends BaseTool {
       'Failed to transfer ERC721' + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[transfer_erc721_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-evm-query-plugin/index.ts
+++ b/packages/core/src/plugins/core-evm-query-plugin/index.ts
@@ -13,10 +13,7 @@ export const coreEVMQueryPlugin: Plugin = {
   },
 };
 
-export {
-  getContractInfoQuery,
-  GET_CONTRACT_INFO_QUERY_TOOL,
-};
+export { getContractInfoQuery, GET_CONTRACT_INFO_QUERY_TOOL };
 
 export const coreEVMQueryPluginToolNames = {
   GET_CONTRACT_INFO_QUERY_TOOL,

--- a/packages/core/src/plugins/core-evm-query-plugin/tools/queries/get-contract-info-query.ts
+++ b/packages/core/src/plugins/core-evm-query-plugin/tools/queries/get-contract-info-query.ts
@@ -98,7 +98,7 @@ export class GetContractInfoQueryTool extends BaseTool {
     );
 
     return {
-      raw: { contractId: contractInfo.contract_id, contractInfo },
+      raw: { contractId: contractInfo.contract_id, contractInfo, status: 'SUCCESS' },
       humanMessage: postProcess(contractInfo),
     };
   }
@@ -115,7 +115,7 @@ export class GetContractInfoQueryTool extends BaseTool {
     const desc = 'Failed to get contract info';
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_contract_info_query_tool]', message);
-    return { raw: { error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-evm-query-plugin/tools/queries/get-contract-info-query.ts
+++ b/packages/core/src/plugins/core-evm-query-plugin/tools/queries/get-contract-info-query.ts
@@ -98,7 +98,7 @@ export class GetContractInfoQueryTool extends BaseTool {
     );
 
     return {
-      raw: { contractId: contractInfo.contract_id, contractInfo, status: 'SUCCESS' },
+      raw: { contractId: contractInfo.contract_id, contractInfo },
       humanMessage: postProcess(contractInfo),
     };
   }
@@ -109,13 +109,6 @@ export class GetContractInfoQueryTool extends BaseTool {
 
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null; // Not applicable for query tools
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get contract info';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_contract_info_query_tool]', message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-misc-query-plugin/index.ts
+++ b/packages/core/src/plugins/core-misc-query-plugin/index.ts
@@ -13,10 +13,7 @@ export const coreMiscQueriesPlugin: Plugin = {
   },
 };
 
-export {
-  getExchangeRateQuery,
-  GET_EXCHANGE_RATE_TOOL,
-};
+export { getExchangeRateQuery, GET_EXCHANGE_RATE_TOOL };
 
 export const coreMiscQueriesPluginsToolNames = {
   GET_EXCHANGE_RATE_TOOL,

--- a/packages/core/src/plugins/core-misc-query-plugin/tools/queries/get-exchange-rate-query.ts
+++ b/packages/core/src/plugins/core-misc-query-plugin/tools/queries/get-exchange-rate-query.ts
@@ -80,7 +80,7 @@ export class GetExchangeRateQueryTool extends BaseTool {
       normalisedParams.timestamp,
     );
     return {
-      raw: rates,
+      raw: { ...rates, status: 'SUCCESS' },
       humanMessage: postProcess(rates),
     };
   }
@@ -98,7 +98,7 @@ export class GetExchangeRateQueryTool extends BaseTool {
     const message = error instanceof Error ? error.message : 'Failed to get exchange rate';
 
     return {
-      raw: { error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-misc-query-plugin/tools/queries/get-exchange-rate-query.ts
+++ b/packages/core/src/plugins/core-misc-query-plugin/tools/queries/get-exchange-rate-query.ts
@@ -80,7 +80,7 @@ export class GetExchangeRateQueryTool extends BaseTool {
       normalisedParams.timestamp,
     );
     return {
-      raw: { ...rates, status: 'SUCCESS' },
+      raw: { ...rates },
       humanMessage: postProcess(rates),
     };
   }
@@ -91,16 +91,6 @@ export class GetExchangeRateQueryTool extends BaseTool {
 
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null; // Not applicable for query tools
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    console.error('[GetExchangeRate] Error getting exchange rate', error);
-    const message = error instanceof Error ? error.message : 'Failed to get exchange rate';
-
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
   }
 }
 

--- a/packages/core/src/plugins/core-token-plugin/tools/associate-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/associate-token.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -40,7 +40,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const ASSOCIATE_TOKEN_TOOL = 'associate_token_tool';
 
-export class AssociateTokenTool extends BaseTool {
+export class AssociateTokenTool extends BaseTransactionTool {
   method = ASSOCIATE_TOKEN_TOOL;
   name = 'Associate Token(s)';
   description: string;
@@ -74,18 +74,8 @@ export class AssociateTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to associate token(s)';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[associate_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new AssociateTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new AssociateTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/associate-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/associate-token.ts
@@ -80,7 +80,7 @@ export class AssociateTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[associate_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/associate-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/associate-token.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { associateTokenParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-token-plugin/tools/dissociate-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/dissociate-token.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -41,7 +41,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const DISSOCIATE_TOKEN_TOOL = 'dissociate_token_tool';
 
-export class DissociateTokenTool extends BaseTool {
+export class DissociateTokenTool extends BaseTransactionTool {
   method = DISSOCIATE_TOKEN_TOOL;
   name = 'Dissociate Token';
   description: string;
@@ -74,18 +74,8 @@ export class DissociateTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to dissociate token';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[dissociate_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new DissociateTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new DissociateTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/dissociate-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/dissociate-token.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { dissociateTokenParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-token-plugin/tools/dissociate-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/dissociate-token.ts
@@ -80,7 +80,7 @@ export class DissociateTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[dissociate_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/airdrop-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/airdrop-fungible-token.ts
@@ -92,7 +92,7 @@ export class AirdropFungibleTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[airdrop_fungible_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/airdrop-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/airdrop-fungible-token.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -46,7 +46,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const AIRDROP_FUNGIBLE_TOKEN_TOOL = 'airdrop_fungible_token_tool';
 
-export class AirdropFungibleTokenTool extends BaseTool {
+export class AirdropFungibleTokenTool extends BaseTransactionTool {
   method = AIRDROP_FUNGIBLE_TOKEN_TOOL;
   name = 'Airdrop Fungible Token';
   description: string;
@@ -86,18 +86,8 @@ export class AirdropFungibleTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to airdrop fungible token';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[airdrop_fungible_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new AirdropFungibleTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new AirdropFungibleTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/airdrop-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/airdrop-fungible-token.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { airdropFungibleTokenParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/approve-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/approve-token-allowance.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { approveTokenAllowanceParameters } from '@/shared/parameter-schemas/account.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/approve-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/approve-token-allowance.ts
@@ -88,7 +88,7 @@ export class ApproveTokenAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[approve_token_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction.toString(), error: message },
+      raw: { status: 'ERROR'.toString(), error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/approve-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/approve-token-allowance.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -43,7 +43,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const APPROVE_TOKEN_ALLOWANCE_TOOL = 'approve_token_allowance_tool';
 
-export class ApproveTokenAllowanceTool extends BaseTool {
+export class ApproveTokenAllowanceTool extends BaseTransactionTool {
   method = APPROVE_TOKEN_ALLOWANCE_TOOL;
   name = 'Approve Token Allowance';
   description: string;
@@ -82,18 +82,8 @@ export class ApproveTokenAllowanceTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to approve token allowance';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[approve_token_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR'.toString(), error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new ApproveTokenAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new ApproveTokenAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/create-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/create-fungible-token.ts
@@ -99,7 +99,7 @@ export class CreateFungibleTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[create_fungible_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/create-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/create-fungible-token.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { createFungibleTokenParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/create-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/create-fungible-token.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -54,7 +54,7 @@ Token ID: ${tokenIdStr}`;
 
 export const CREATE_FUNGIBLE_TOKEN_TOOL = 'create_fungible_token_tool';
 
-export class CreateFungibleTokenTool extends BaseTool {
+export class CreateFungibleTokenTool extends BaseTransactionTool {
   method = CREATE_FUNGIBLE_TOKEN_TOOL;
   name = 'Create Fungible Token';
   description: string;
@@ -93,18 +93,8 @@ export class CreateFungibleTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to create fungible token';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[create_fungible_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new CreateFungibleTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new CreateFungibleTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/delete-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/delete-token-allowance.ts
@@ -87,7 +87,7 @@ export class DeleteTokenAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[delete_token_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/delete-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/delete-token-allowance.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import { deleteTokenAllowanceParameters } from '@/shared/parameter-schemas/account.zod';

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/delete-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/delete-token-allowance.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -42,7 +42,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const DELETE_TOKEN_ALLOWANCE_TOOL = 'delete_token_allowance_tool';
 
-export class DeleteTokenAllowanceTool extends BaseTool {
+export class DeleteTokenAllowanceTool extends BaseTransactionTool {
   method = DELETE_TOKEN_ALLOWANCE_TOOL;
   name = 'Delete Token Allowance';
   description: string;
@@ -81,18 +81,8 @@ export class DeleteTokenAllowanceTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to delete token allowance(s).';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[delete_token_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new DeleteTokenAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new DeleteTokenAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/mint-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/mint-fungible-token.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { mintFungibleTokenParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/mint-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/mint-fungible-token.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -43,7 +43,7 @@ Transaction ID: ${response.transactionId.toString()}`;
 
 export const MINT_FUNGIBLE_TOKEN_TOOL = 'mint_fungible_token_tool';
 
-export class MintFungibleTokenTool extends BaseTool {
+export class MintFungibleTokenTool extends BaseTransactionTool {
   method = MINT_FUNGIBLE_TOKEN_TOOL;
   name = 'Mint Fungible Token';
   description: string;
@@ -82,18 +82,8 @@ export class MintFungibleTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to mint fungible token';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[mint_fungible_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new MintFungibleTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new MintFungibleTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/mint-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/mint-fungible-token.ts
@@ -88,7 +88,7 @@ export class MintFungibleTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[mint_fungible_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/transfer-fungible-token-with-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/transfer-fungible-token-with-allowance.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -51,7 +51,7 @@ Transaction ID: ${response.transactionId}`;
 export const TRANSFER_FUNGIBLE_TOKEN_WITH_ALLOWANCE_TOOL =
   'transfer_fungible_token_with_allowance_tool';
 
-export class TransferFungibleTokenWithAllowanceTool extends BaseTool {
+export class TransferFungibleTokenWithAllowanceTool extends BaseTransactionTool {
   method = TRANSFER_FUNGIBLE_TOKEN_WITH_ALLOWANCE_TOOL;
   name = 'Transfer Fungible Token with Allowance';
   description: string;
@@ -90,18 +90,8 @@ export class TransferFungibleTokenWithAllowanceTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to transfer fungible token with allowance';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[transfer_fungible_token_with_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new TransferFungibleTokenWithAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new TransferFungibleTokenWithAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/transfer-fungible-token-with-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/transfer-fungible-token-with-allowance.ts
@@ -96,7 +96,7 @@ export class TransferFungibleTokenWithAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[transfer_fungible_token_with_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/fungible-token/transfer-fungible-token-with-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/fungible-token/transfer-fungible-token-with-allowance.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { transferFungibleTokenWithAllowanceParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -92,6 +89,7 @@ export class TransferFungibleTokenWithAllowanceTool extends BaseTransactionTool 
   }
 }
 
-const tool = (context: Context): BaseTransactionTool => new TransferFungibleTokenWithAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool =>
+  new TransferFungibleTokenWithAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/approve-non-fungible-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/approve-non-fungible-token-allowance.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -44,7 +44,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const APPROVE_NFT_ALLOWANCE_TOOL = 'approve_nft_allowance_tool';
 
-export class ApproveNftAllowanceTool extends BaseTool {
+export class ApproveNftAllowanceTool extends BaseTransactionTool {
   method = APPROVE_NFT_ALLOWANCE_TOOL;
   name = 'Approve NFT Allowance';
   description: string;
@@ -78,18 +78,8 @@ export class ApproveNftAllowanceTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to Approve NFT allowance';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[approve_nft_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new ApproveNftAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new ApproveNftAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/approve-non-fungible-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/approve-non-fungible-token-allowance.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { approveNftAllowanceParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -48,7 +45,7 @@ export class ApproveNftAllowanceTool extends BaseTransactionTool {
   method = APPROVE_NFT_ALLOWANCE_TOOL;
   name = 'Approve NFT Allowance';
   description: string;
-  parameters:  ReturnType<typeof approveNftAllowanceParameters>;
+  parameters: ReturnType<typeof approveNftAllowanceParameters>;
   outputParser = transactionToolOutputParser;
 
   constructor(context: Context) {

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/approve-non-fungible-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/approve-non-fungible-token-allowance.ts
@@ -84,7 +84,7 @@ export class ApproveNftAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[approve_nft_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/create-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/create-non-fungible-token.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -55,7 +55,7 @@ Token ID: ${tokenIdStr}`;
 
 export const CREATE_NON_FUNGIBLE_TOKEN_TOOL = 'create_non_fungible_token_tool';
 
-export class CreateNonFungibleTokenTool extends BaseTool {
+export class CreateNonFungibleTokenTool extends BaseTransactionTool {
   method = CREATE_NON_FUNGIBLE_TOKEN_TOOL;
   name = 'Create Non-Fungible Token';
   description: string;
@@ -94,18 +94,8 @@ export class CreateNonFungibleTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to create non-fungible token';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[create_non_fungible_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new CreateNonFungibleTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new CreateNonFungibleTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/create-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/create-non-fungible-token.ts
@@ -100,7 +100,7 @@ export class CreateNonFungibleTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[create_non_fungible_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/create-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/create-non-fungible-token.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { createNonFungibleTokenParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/delete-non-fungible-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/delete-non-fungible-token-allowance.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -42,7 +42,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const DELETE_NFT_ALLOWANCE_TOOL = 'delete_non_fungible_token_allowance_tool';
 
-export class DeleteNftAllowanceTool extends BaseTool {
+export class DeleteNftAllowanceTool extends BaseTransactionTool {
   method = DELETE_NFT_ALLOWANCE_TOOL;
   name = 'Delete Non Fungible Token Allowance';
   description: string;
@@ -75,18 +75,8 @@ export class DeleteNftAllowanceTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to delete NFT allowance';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[delete_non_fungible_token_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new DeleteNftAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new DeleteNftAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/delete-non-fungible-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/delete-non-fungible-token-allowance.ts
@@ -81,7 +81,7 @@ export class DeleteNftAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[delete_non_fungible_token_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/delete-non-fungible-token-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/delete-non-fungible-token-allowance.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { deleteNftAllowanceParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/mint-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/mint-non-fungible-token.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -55,7 +55,7 @@ Serial(s): ${serialsStr}`;
 
 export const MINT_NON_FUNGIBLE_TOKEN_TOOL = 'mint_non_fungible_token_tool';
 
-export class MintNonFungibleTokenTool extends BaseTool {
+export class MintNonFungibleTokenTool extends BaseTransactionTool {
   method = MINT_NON_FUNGIBLE_TOKEN_TOOL;
   name = 'Mint Non-Fungible Token';
   description: string;
@@ -88,18 +88,8 @@ export class MintNonFungibleTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to mint non-fungible token';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[mint_non_fungible_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new MintNonFungibleTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new MintNonFungibleTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/mint-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/mint-non-fungible-token.ts
@@ -94,7 +94,7 @@ export class MintNonFungibleTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[mint_non_fungible_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/mint-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/mint-non-fungible-token.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import { mintNonFungibleTokenParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token-with-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token-with-allowance.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { transferNonFungibleTokenWithAllowanceParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -79,6 +76,7 @@ export class TransferNonFungibleTokenWithAllowanceTool extends BaseTransactionTo
   }
 }
 
-const tool = (context: Context): BaseTransactionTool => new TransferNonFungibleTokenWithAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool =>
+  new TransferNonFungibleTokenWithAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token-with-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token-with-allowance.ts
@@ -83,7 +83,7 @@ export class TransferNonFungibleTokenWithAllowanceTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[transfer_non_fungible_token_with_allowance_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token-with-allowance.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token-with-allowance.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -41,7 +41,7 @@ const postProcess = (response: RawTransactionResponse) => {
 export const TRANSFER_NON_FUNGIBLE_TOKEN_WITH_ALLOWANCE_TOOL =
   'transfer_non_fungible_token_with_allowance_tool';
 
-export class TransferNonFungibleTokenWithAllowanceTool extends BaseTool {
+export class TransferNonFungibleTokenWithAllowanceTool extends BaseTransactionTool {
   method = TRANSFER_NON_FUNGIBLE_TOKEN_WITH_ALLOWANCE_TOOL;
   name = 'Transfer Non Fungible Token with Allowance';
   description: string;
@@ -77,18 +77,8 @@ export class TransferNonFungibleTokenWithAllowanceTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to transfer non-fungible token with allowance';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[transfer_non_fungible_token_with_allowance_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new TransferNonFungibleTokenWithAllowanceTool(context);
+const tool = (context: Context): BaseTransactionTool => new TransferNonFungibleTokenWithAllowanceTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token.ts
@@ -83,7 +83,7 @@ export class TransferNonFungibleTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[transfer_non_fungible_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token.ts
@@ -2,10 +2,7 @@ import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client } from '@hiero-ledger/sdk';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import { transferNonFungibleTokenParameters } from '@/shared/parameter-schemas/token.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';

--- a/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/non-fungible-token/transfer-non-fungible-token.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client } from '@hiero-ledger/sdk';
 import {
   handleTransaction,
   RawTransactionResponse,
@@ -44,7 +44,7 @@ Schedule ID: ${response.scheduleId.toString()}`;
 
 export const TRANSFER_NON_FUNGIBLE_TOKEN_TOOL = 'transfer_non_fungible_token_tool';
 
-export class TransferNonFungibleTokenTool extends BaseTool {
+export class TransferNonFungibleTokenTool extends BaseTransactionTool {
   method = TRANSFER_NON_FUNGIBLE_TOKEN_TOOL;
   name = 'Transfer Non Fungible Token';
   description: string;
@@ -77,18 +77,8 @@ export class TransferNonFungibleTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to transfer non-fungible token';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[transfer_non_fungible_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new TransferNonFungibleTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new TransferNonFungibleTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/update-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/update-token.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { Context } from '@/shared/configuration';
-import { BaseTool } from '@/shared/tools';
-import { Client, PublicKey, Status } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Client, PublicKey } from '@hiero-ledger/sdk';
 import { TokenInfo } from '@/shared/hedera-utils/mirrornode/types';
 import {
   handleTransaction,
@@ -113,7 +113,7 @@ const postProcess = (response: RawTransactionResponse) => {
 
 export const UPDATE_TOKEN_TOOL = 'update_token_tool';
 
-export class UpdateTokenTool extends BaseTool {
+export class UpdateTokenTool extends BaseTransactionTool {
   method = UPDATE_TOKEN_TOOL;
   name = 'Update Token';
   description: string;
@@ -152,18 +152,8 @@ export class UpdateTokenTool extends BaseTool {
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
   }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to update token';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[update_token_tool]', message);
-    return {
-      raw: { status: 'ERROR', error: message },
-      humanMessage: message,
-    };
-  }
 }
 
-const tool = (context: Context): BaseTool => new UpdateTokenTool(context);
+const tool = (context: Context): BaseTransactionTool => new UpdateTokenTool(context);
 
 export default tool;

--- a/packages/core/src/plugins/core-token-plugin/tools/update-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/update-token.ts
@@ -3,10 +3,7 @@ import type { Context } from '@/shared/configuration';
 import { BaseTransactionTool } from '@/shared/base-transaction-tool';
 import { Client, PublicKey } from '@hiero-ledger/sdk';
 import { TokenInfo } from '@/shared/hedera-utils/mirrornode/types';
-import {
-  handleTransaction,
-  RawTransactionResponse,
-} from '@/shared/strategies/tx-mode-strategy';
+import { handleTransaction, RawTransactionResponse } from '@/shared/strategies/tx-mode-strategy';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';

--- a/packages/core/src/plugins/core-token-plugin/tools/update-token.ts
+++ b/packages/core/src/plugins/core-token-plugin/tools/update-token.ts
@@ -158,7 +158,7 @@ export class UpdateTokenTool extends BaseTool {
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[update_token_tool]', message);
     return {
-      raw: { status: Status.InvalidTransaction, error: message },
+      raw: { status: 'ERROR', error: message },
       humanMessage: message,
     };
   }

--- a/packages/core/src/plugins/core-token-query-plugin/tools/queries/get-pending-airdrop-query.ts
+++ b/packages/core/src/plugins/core-token-query-plugin/tools/queries/get-pending-airdrop-query.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Context } from '@/shared/configuration';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { BaseTool } from '@/shared/tools';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import {
@@ -138,7 +138,7 @@ export class GetPendingAirdropQueryTool extends BaseTool {
     };
 
     return {
-      raw: { accountId, pendingAirdrops: enrichedResponse },
+      raw: { accountId, pendingAirdrops: enrichedResponse, status: 'SUCCESS' },
       humanMessage: postProcess(accountId, enrichedAirdrops),
     };
   }
@@ -155,7 +155,7 @@ export class GetPendingAirdropQueryTool extends BaseTool {
     const desc = 'Failed to get pending airdrops';
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_pending_airdrop_query_tool]', message);
-    return { raw: { status: Status.InvalidTransaction, error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-token-query-plugin/tools/queries/get-pending-airdrop-query.ts
+++ b/packages/core/src/plugins/core-token-query-plugin/tools/queries/get-pending-airdrop-query.ts
@@ -138,7 +138,7 @@ export class GetPendingAirdropQueryTool extends BaseTool {
     };
 
     return {
-      raw: { accountId, pendingAirdrops: enrichedResponse, status: 'SUCCESS' },
+      raw: { accountId, pendingAirdrops: enrichedResponse },
       humanMessage: postProcess(accountId, enrichedAirdrops),
     };
   }
@@ -149,13 +149,6 @@ export class GetPendingAirdropQueryTool extends BaseTool {
 
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get pending airdrops';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_pending_airdrop_query_tool]', message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-token-query-plugin/tools/queries/get-token-info-query.ts
+++ b/packages/core/src/plugins/core-token-query-plugin/tools/queries/get-token-info-query.ts
@@ -100,7 +100,7 @@ export class GetTokenInfoQueryTool extends BaseTool {
     };
 
     return {
-      raw: { tokenId: normalisedParams.tokenId, tokenInfo, status: 'SUCCESS' },
+      raw: { tokenId: normalisedParams.tokenId, tokenInfo },
       humanMessage: postProcess(tokenInfo),
     };
   }
@@ -111,13 +111,6 @@ export class GetTokenInfoQueryTool extends BaseTool {
 
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get token info';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_token_info_query_tool]', message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-token-query-plugin/tools/queries/get-token-info-query.ts
+++ b/packages/core/src/plugins/core-token-query-plugin/tools/queries/get-token-info-query.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { Context } from '@/shared/configuration';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
 import { tokenInfoQueryParameters } from '@/shared/parameter-schemas/token.zod';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { BaseTool } from '@/shared/tools';
 import { PromptGenerator } from '@/shared/utils/prompt-generator';
 import { TokenInfo } from '@/shared/hedera-utils/mirrornode/types';
@@ -100,7 +100,7 @@ export class GetTokenInfoQueryTool extends BaseTool {
     };
 
     return {
-      raw: { tokenId: normalisedParams.tokenId, tokenInfo },
+      raw: { tokenId: normalisedParams.tokenId, tokenInfo, status: 'SUCCESS' },
       humanMessage: postProcess(tokenInfo),
     };
   }
@@ -117,7 +117,7 @@ export class GetTokenInfoQueryTool extends BaseTool {
     const desc = 'Failed to get token info';
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_token_info_query_tool]', message);
-    return { raw: { status: Status.InvalidTransaction, error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-transactions-query-plugin/index.ts
+++ b/packages/core/src/plugins/core-transactions-query-plugin/index.ts
@@ -13,10 +13,7 @@ export const coreTransactionQueryPlugin: Plugin = {
   },
 };
 
-export {
-  getTransactionRecordQuery,
-  GET_TRANSACTION_RECORD_QUERY_TOOL,
-};
+export { getTransactionRecordQuery, GET_TRANSACTION_RECORD_QUERY_TOOL };
 
 export const coreTransactionQueryPluginToolNames = {
   GET_TRANSACTION_RECORD_QUERY_TOOL,

--- a/packages/core/src/plugins/core-transactions-query-plugin/tools/queries/get-transaction-record-query.ts
+++ b/packages/core/src/plugins/core-transactions-query-plugin/tools/queries/get-transaction-record-query.ts
@@ -98,7 +98,6 @@ export class GetTransactionRecordQueryTool extends BaseTool {
       raw: {
         transactionId: normalisedParams.transactionId,
         transactionRecord: transactionRecord,
-        status: 'SUCCESS',
       },
       humanMessage: postProcess(transactionRecord, normalisedParams.transactionId),
     };
@@ -110,13 +109,6 @@ export class GetTransactionRecordQueryTool extends BaseTool {
 
   async secondaryAction(_transaction: any, _client: Client, _context: Context) {
     return null;
-  }
-
-  async handleError(error: unknown, _context: Context): Promise<any> {
-    const desc = 'Failed to get transaction record';
-    const message = desc + (error instanceof Error ? `: ${error.message}` : '');
-    console.error('[get_transaction_record_query_tool]', message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/plugins/core-transactions-query-plugin/tools/queries/get-transaction-record-query.ts
+++ b/packages/core/src/plugins/core-transactions-query-plugin/tools/queries/get-transaction-record-query.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { Context } from '@/shared/configuration';
 import { getMirrornodeService } from '@/shared/hedera-utils/mirrornode/hedera-mirrornode-utils';
 import { BaseTool } from '@/shared/tools';
@@ -98,6 +98,7 @@ export class GetTransactionRecordQueryTool extends BaseTool {
       raw: {
         transactionId: normalisedParams.transactionId,
         transactionRecord: transactionRecord,
+        status: 'SUCCESS',
       },
       humanMessage: postProcess(transactionRecord, normalisedParams.transactionId),
     };
@@ -115,7 +116,7 @@ export class GetTransactionRecordQueryTool extends BaseTool {
     const desc = 'Failed to get transaction record';
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error('[get_transaction_record_query_tool]', message);
-    return { raw: { status: Status.InvalidTransaction, error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 }
 

--- a/packages/core/src/shared/base-transaction-tool.ts
+++ b/packages/core/src/shared/base-transaction-tool.ts
@@ -1,34 +1,46 @@
-import { ReceiptStatusError } from '@hiero-ledger/sdk';
+import { PrecheckStatusError, ReceiptStatusError } from '@hiero-ledger/sdk';
 import { BaseTool } from './tools';
 import { Context } from './configuration';
+import { TOOL_STATUS } from '@/shared/utils';
 
 /**
  * Abstract base class for all Hedera transaction tools.
  *
  * Extends {@link BaseTool} with Hedera-specific error handling: when a
- * `ReceiptStatusError` is thrown (i.e. `ExecuteStrategy` received a non-SUCCESS
- * receipt from the network), the SDK status name and transaction ID are lifted
- * into structured fields on `raw` so callers don't need to parse prose.
+ * `ReceiptStatusError` or `PrecheckStatusError` is thrown, the SDK status name
+ * and transaction ID are lifted into structured fields on `raw` so callers
+ * don't need to parse prose.
  *
- * On successful execution `raw.status` is `'SUCCESS'` (set by `ExecuteStrategy`).
- * When a `ReceiptStatusError` is caught by `handleError()`, `raw.status` is
- * `'ERROR'` and the following additional fields are set:
+ * - `ReceiptStatusError` — thrown by `ExecuteStrategy` when `getReceipt()` returns
+ *   a non-SUCCESS status (e.g. `TOKEN_NOT_ASSOCIATED_TO_ACCOUNT`).
+ * - `PrecheckStatusError` — thrown before a transaction reaches the network when
+ *   the node rejects it at the precheck stage (e.g. `INSUFFICIENT_PAYER_BALANCE`).
+ *
+ * Both error types expose `.status` (SDK `Status` enum) and `.transactionId`
+ * (`TransactionId`), so the same structured fields are set for both:
+ * - `raw.status` — always `'ERROR'`
  * - `raw.errorCode` — SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`
  * - `raw.transactionId` — the transaction ID string
  * - `raw.error` — the original error message
  *
- * This behaviour only applies in `AUTONOMOUS` mode. In
- * `RETURN_BYTES` mode `getReceipt()` is never called, so `ReceiptStatusError`
- * cannot be thrown and `BaseTool.handleError()` handles all errors generically.
+ * On successful execution `raw.status` is `'SUCCESS'` (defaulted by
+ * `BaseTool.execute()` if not set explicitly upstream by `ExecuteStrategy` or
+ * `ReturnBytesStrategy`).
+ *
+ * This behaviour only applies in `AUTONOMOUS` mode. In `RETURN_BYTES` mode
+ * `getReceipt()` is never called, so `ReceiptStatusError` cannot be thrown.
+ * `PrecheckStatusError` can in principle still be thrown in `RETURN_BYTES` mode
+ * if the node rejects the submission itself, but in practice the bytes are
+ * returned before submission and `BaseTool.handleError()` handles all errors.
  */
 export abstract class BaseTransactionTool extends BaseTool {
   async handleError(error: unknown, context: Context): Promise<any> {
-    if (error instanceof ReceiptStatusError) {
+    if (error instanceof ReceiptStatusError || error instanceof PrecheckStatusError) {
       const message = `Failed to execute ${this.name}: ${error.message}`;
       console.error(`[${this.method}]`, message);
       return {
         raw: {
-          status: 'ERROR',
+          status: TOOL_STATUS.ERROR,
           errorCode: error.status.toString(),
           transactionId: error.transactionId.toString(),
           error: error.message,

--- a/packages/core/src/shared/base-transaction-tool.ts
+++ b/packages/core/src/shared/base-transaction-tool.ts
@@ -1,0 +1,39 @@
+import { ReceiptStatusError } from '@hiero-ledger/sdk';
+import { BaseTool } from './tools';
+import { Context } from './configuration';
+
+/**
+ * Abstract base class for all Hedera transaction tools.
+ *
+ * Extends {@link BaseTool} with Hedera-specific error handling: when a
+ * `ReceiptStatusError` is thrown (i.e. `ExecuteStrategy` received a non-SUCCESS
+ * receipt from the network), the SDK status name and transaction ID are lifted
+ * into structured fields on `raw` so callers don't need to parse prose.
+ *
+ * `raw.status` is always `'ERROR'`; the additional fields are:
+ * - `raw.errorCode` — SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`
+ * - `raw.transactionId` — the transaction ID string
+ * - `raw.error` — the original error message
+ *
+ * This behaviour only applies in `AUTONOMUS` mode. In
+ * `RETURN_BYTES` mode `getReceipt()` is never called, so `ReceiptStatusError`
+ * cannot be thrown and `BaseTool.handleError()` handles all errors generically.
+ */
+export abstract class BaseTransactionTool extends BaseTool {
+  async handleError(error: unknown, context: Context): Promise<any> {
+    if (error instanceof ReceiptStatusError) {
+      const message = `Failed to execute ${this.name}: ${error.message}`;
+      console.error(`[${this.method}]`, message);
+      return {
+        raw: {
+          status: 'ERROR',
+          errorCode: error.status.toString(),
+          transactionId: error.transactionId.toString(),
+          error: error.message,
+        },
+        humanMessage: message,
+      };
+    }
+    return super.handleError(error, context);
+  }
+}

--- a/packages/core/src/shared/base-transaction-tool.ts
+++ b/packages/core/src/shared/base-transaction-tool.ts
@@ -1,7 +1,7 @@
 import { PrecheckStatusError, ReceiptStatusError } from '@hiero-ledger/sdk';
 import { BaseTool } from './tools';
 import { Context } from './configuration';
-import { TOOL_STATUS } from '@/shared/utils';
+import { TOOL_STATUS } from './utils/default-tool-output-parsing';
 
 /**
  * Abstract base class for all Hedera transaction tools.

--- a/packages/core/src/shared/base-transaction-tool.ts
+++ b/packages/core/src/shared/base-transaction-tool.ts
@@ -10,12 +10,14 @@ import { Context } from './configuration';
  * receipt from the network), the SDK status name and transaction ID are lifted
  * into structured fields on `raw` so callers don't need to parse prose.
  *
- * `raw.status` is always `'ERROR'`; the additional fields are:
+ * On successful execution `raw.status` is `'SUCCESS'` (set by `ExecuteStrategy`).
+ * When a `ReceiptStatusError` is caught by `handleError()`, `raw.status` is
+ * `'ERROR'` and the following additional fields are set:
  * - `raw.errorCode` — SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`
  * - `raw.transactionId` — the transaction ID string
  * - `raw.error` — the original error message
  *
- * This behaviour only applies in `AUTONOMUS` mode. In
+ * This behaviour only applies in `AUTONOMOUS` mode. In
  * `RETURN_BYTES` mode `getReceipt()` is never called, so `ReceiptStatusError`
  * cannot be thrown and `BaseTool.handleError()` handles all errors generically.
  */

--- a/packages/core/src/shared/hedera-utils/decimals-utils.ts
+++ b/packages/core/src/shared/hedera-utils/decimals-utils.ts
@@ -17,17 +17,10 @@ export async function getERC20Decimals(
   mirrorNode: IHederaMirrornodeService,
 ): Promise<number> {
   const contractInfo = await mirrorNode.getContractInfo(contractId);
-  const response = await fetch(`${mirrorNode.getBaseUrl()}/contracts/call`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ data: ERC20_DECIMALS_SELECTOR, to: contractInfo.evm_address }),
-  });
-  if (!response.ok) {
-    throw new Error(
-      `Failed to read decimals of ERC20 contract ${contractId}: ${response.status} ${response.statusText}`,
-    );
+  if (!contractInfo.evm_address) {
+    throw new Error(`ERC20 contract ${contractId} has no EVM address`);
   }
-  const { result } = (await response.json()) as { result: string };
+  const result = await mirrorNode.callContract(contractInfo.evm_address, ERC20_DECIMALS_SELECTOR);
   return Number(BigInt(result));
 }
 

--- a/packages/core/src/shared/hedera-utils/hedera-parameter-normaliser.ts
+++ b/packages/core/src/shared/hedera-utils/hedera-parameter-normaliser.ts
@@ -48,7 +48,7 @@ import {
   transferHbarWithAllowanceParameters,
   transferHbarWithAllowanceParametersNormalised,
   updateAccountParameters,
-  updateAccountParametersNormalised
+  updateAccountParametersNormalised,
 } from '@/shared/parameter-schemas/account.zod';
 import {
   createTopicParameters,
@@ -79,7 +79,7 @@ import {
 } from '@hiero-ledger/sdk';
 import { Context } from '@/shared/configuration';
 import z from 'zod';
-import { IHederaMirrornodeService } from './mirrornode/hedera-mirrornode-service.interface';
+import { IHederaMirrornodeService } from '@/shared';
 import { getERC20Decimals, toBaseUnit } from './decimals-utils';
 import { TokenTransferMinimalParams, TransferHbarInput } from './types';
 import { AccountResolver } from '@/shared/utils/account-resolver';

--- a/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
+++ b/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
@@ -256,6 +256,19 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
     );
   }
 
+  async callContract(to: string, data: string): Promise<string> {
+    const response = await fetch(`${this.baseUrl}/contracts/call`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data, to }),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to call contract ${to}: ${response.status} ${response.statusText}`);
+    }
+    const { result } = (await response.json()) as { result: string };
+    return result;
+  }
+
   getBaseUrl(): string {
     return this.baseUrl;
   }

--- a/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
+++ b/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service-default-impl.ts
@@ -139,7 +139,8 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
         fetchedMessages += 1;
         const data: TopicMessagesAPIResponse = await this.fetchJson<TopicMessagesAPIResponse>(
           url,
-          r => `Failed to get topic messages for ${queryParams.topicId}: ${r.status} ${r.statusText}`,
+          r =>
+            `Failed to get topic messages for ${queryParams.topicId}: ${r.status} ${r.statusText}`,
         );
 
         arrayOfMessages.push(...data.messages);
@@ -203,7 +204,8 @@ export class HederaMirrornodeServiceDefaultImpl implements IHederaMirrornodeServ
     const url = `${this.baseUrl}/accounts/${accountId}/airdrops/pending`;
     return this.fetchJson<TokenAirdropsResponse>(
       url,
-      r => `Failed to fetch pending airdrops for an account ${accountId}: ${r.status} ${r.statusText}`,
+      r =>
+        `Failed to fetch pending airdrops for an account ${accountId}: ${r.status} ${r.statusText}`,
     );
   }
 

--- a/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface.ts
+++ b/packages/core/src/shared/hedera-utils/mirrornode/hedera-mirrornode-service.interface.ts
@@ -33,5 +33,6 @@ export interface IHederaMirrornodeService {
   ): Promise<TokenAllowanceResponse>;
   getAccountNfts(accountId: string): Promise<NftBalanceResponse>;
   getScheduledTransactionDetails(scheduleId: string): Promise<ScheduledTransactionDetailsResponse>;
+  callContract(to: string, data: string): Promise<string>;
   getBaseUrl(): string;
 }

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './api';
+export * from './base-transaction-tool';
 export * from './configuration';
 export * from './tools';
 export * from './plugin';

--- a/packages/core/src/shared/parameter-schemas/account.zod.ts
+++ b/packages/core/src/shared/parameter-schemas/account.zod.ts
@@ -9,7 +9,7 @@ import {
 
 // Structural check on `__isLong__`; survives ESM/CJS dual copies where an instanceof
 // check against the imported Long constructor would silently fail.
-const zLong = z.custom<Long>((v) => Long.isLong(v), { message: 'Expected Long' });
+const zLong = z.custom<Long>(v => Long.isLong(v), { message: 'Expected Long' });
 
 export const transferHbarParameters = (context: Context = {}) =>
   optionalScheduledTransactionParams(context).extend({

--- a/packages/core/src/shared/parameter-schemas/consensus.zod.ts
+++ b/packages/core/src/shared/parameter-schemas/consensus.zod.ts
@@ -14,10 +14,7 @@ export const getTopicInfoParameters = (_context: Context = {}) => {
 
 export const createTopicParameters = (_context: Context = {}) => {
   return optionalScheduledTransactionParams(_context).extend({
-    isSubmitKey: z
-      .boolean()
-      .optional()
-      .describe('Deprecated: use submitKey instead (optional)'),
+    isSubmitKey: z.boolean().optional().describe('Deprecated: use submitKey instead (optional)'),
     submitKey: z
       .union([z.boolean(), z.string()])
       .optional()

--- a/packages/core/src/shared/parameter-schemas/evm.zod.ts
+++ b/packages/core/src/shared/parameter-schemas/evm.zod.ts
@@ -24,11 +24,7 @@ export const transferERC20Parameters = (context: Context = {}) =>
   optionalScheduledTransactionParams(context).extend({
     contractId: z.string().describe('The id of the ERC20 contract.'),
     recipientAddress: z.string().describe('Address to which the tokens will be transferred.'),
-    amount: z
-      .number()
-      .describe(
-        'The amount of tokens to transfer. Given in display units.',
-      ),
+    amount: z.number().describe('The amount of tokens to transfer. Given in display units.'),
   });
 
 export const createERC721Parameters = (context: Context = {}) =>
@@ -55,9 +51,7 @@ export const createERC20Parameters = (context: Context = {}) =>
       .min(0)
       .optional()
       .default(0)
-      .describe(
-        'The initial supply of the token. Given in display units.',
-      ),
+      .describe('The initial supply of the token. Given in display units.'),
   });
 
 export const transferERC721Parameters = (context: Context = {}) =>

--- a/packages/core/src/shared/strategies/tx-mode-strategy.ts
+++ b/packages/core/src/shared/strategies/tx-mode-strategy.ts
@@ -64,6 +64,12 @@ export class ExecuteStrategy implements TxModeStrategy {
 }
 
 class ReturnBytesStrategy implements TxModeStrategy {
+  /**
+   * Serialises the transaction to bytes instead of submitting it.
+   *
+   * `raw.status` is always `'SUCCESS'` and `raw.bytes` contains the serialised
+   * transaction.`
+   */
   async handle(tx: Transaction, client: Client, context: Context) {
     if (!context.accountId)
       throw new Error('Account ID is required in context for RETURN_BYTES mode');

--- a/packages/core/src/shared/strategies/tx-mode-strategy.ts
+++ b/packages/core/src/shared/strategies/tx-mode-strategy.ts
@@ -8,6 +8,7 @@ import {
   TransactionId,
 } from '@hiero-ledger/sdk';
 import { AgentMode, Context } from '@/shared/configuration';
+import { TOOL_STATUS } from '@/shared/utils/default-tool-output-parsing';
 
 interface TxModeStrategy {
   handle<T extends Transaction>(
@@ -75,7 +76,7 @@ class ReturnBytesStrategy implements TxModeStrategy {
       throw new Error('Account ID is required in context for RETURN_BYTES mode');
     const id = TransactionId.generate(context.accountId);
     tx.setTransactionId(id).freezeWith(client);
-    return { bytes: tx.toBytes(), status: 'SUCCESS' };
+    return { bytes: tx.toBytes(), status: TOOL_STATUS.SUCCESS };
   }
 }
 

--- a/packages/core/src/shared/strategies/tx-mode-strategy.ts
+++ b/packages/core/src/shared/strategies/tx-mode-strategy.ts
@@ -69,7 +69,7 @@ class ReturnBytesStrategy implements TxModeStrategy {
       throw new Error('Account ID is required in context for RETURN_BYTES mode');
     const id = TransactionId.generate(context.accountId);
     tx.setTransactionId(id).freezeWith(client);
-    return { bytes: tx.toBytes() };
+    return { bytes: tx.toBytes(), status: 'SUCCESS' };
   }
 }
 

--- a/packages/core/src/shared/strategies/tx-mode-strategy.ts
+++ b/packages/core/src/shared/strategies/tx-mode-strategy.ts
@@ -68,7 +68,7 @@ class ReturnBytesStrategy implements TxModeStrategy {
    * Serialises the transaction to bytes instead of submitting it.
    *
    * `raw.status` is always `'SUCCESS'` and `raw.bytes` contains the serialised
-   * transaction.`
+   * transaction.
    */
   async handle(tx: Transaction, client: Client, context: Context) {
     if (!context.accountId)

--- a/packages/core/src/shared/strategies/tx-mode-strategy.ts
+++ b/packages/core/src/shared/strategies/tx-mode-strategy.ts
@@ -52,7 +52,7 @@ export class ExecuteStrategy implements TxModeStrategy {
       status: receipt.status.toString(),
       accountId: receipt.accountId,
       tokenId: receipt.tokenId,
-      serials: receipt.serials.map((s) => s.toString()),
+      serials: receipt.serials.map(s => s.toString()),
       transactionId: tx.transactionId?.toString() ?? '',
       topicId: receipt.topicId,
       scheduleId: receipt.scheduleId,

--- a/packages/core/src/shared/tools.ts
+++ b/packages/core/src/shared/tools.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { Client } from '@hiero-ledger/sdk';
 import { Context } from './configuration';
+import { TOOL_STATUS } from '@/shared/utils';
 
 import {
   PreToolExecutionParams,
@@ -31,8 +32,8 @@ export interface Tool {
  *
  * | `raw.status`    | Source                                          | Meaning                                                                 |
  * |-----------------|-------------------------------------------------|-------------------------------------------------------------------------|
- * | `'SUCCESS'`     | `coreAction` (query tools) or `ExecuteStrategy` | Operation completed successfully                                         |
- * | `'ERROR'`       | `BaseTool.handleError()` / `BaseTransactionTool.handleError()` | Caught exception. Transaction tools extend `BaseTransactionTool`, which additionally sets `raw.errorCode` (specific SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId` for Hedera receipt failures. |
+ * | `'SUCCESS'`     | `BaseTool.execute()` (defaulted via `??=`), `ReturnBytesStrategy`, or `ExecuteStrategy` | Operation completed successfully. Any tool that reaches the end of `execute()` without an explicit `raw.status` is automatically assigned `'SUCCESS'`. |
+ * | `'ERROR'`       | `BaseTool.handleError()` / `BaseTransactionTool.handleError()` | Caught exception. Transaction tools extend `BaseTransactionTool`, which additionally sets `raw.errorCode` (specific SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId` for Hedera receipt/precheck failures. |
  * | `'PARSE_ERROR'` | `transactionToolOutputParser` / `untypedQueryOutputParser` | Output is not valid JSON or has an unexpected shape.                     |
  *
  * Use {@link classifyToolResult} to map these into the stable
@@ -77,6 +78,13 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
       let result = coreActionResult;
       if (await this.shouldSecondaryAction(coreActionResult, context)) {
         result = await this.secondaryAction(coreActionResult, client, context); // optional secondary action like tx signing, is not required for query tools and can be omitted
+      }
+
+      // Default raw.status to SUCCESS for any tool that did not set it explicitly.
+      // ExecuteStrategy and ReturnBytesStrategy already set it; this covers query
+      // tools and third-party tools that return a raw envelope without a status.
+      if (result && typeof result.raw === 'object' && result.raw !== null) {
+        result.raw.status ??= TOOL_STATUS.SUCCESS;
       }
 
       // 7. PostToolExecutionHook
@@ -155,13 +163,14 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
    * Default error handler called when any step of `execute()` throws.
    * Returns `{ raw: { status: 'ERROR', error: string }, humanMessage: string }`.
    * Transaction tools extend `BaseTransactionTool` which overrides this to
-   * additionally extract structured fields from `ReceiptStatusError`.
+   * additionally extract structured fields from `ReceiptStatusError` and
+   * `PrecheckStatusError`.
    */
   async handleError(error: unknown, _context: Context): Promise<any> {
     const desc = `Failed to execute ${this.name}`;
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error(`[${this.method}]`, message);
-    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
+    return { raw: { status: TOOL_STATUS.ERROR, error: message }, humanMessage: message };
   }
 
   // Abstract steps

--- a/packages/core/src/shared/tools.ts
+++ b/packages/core/src/shared/tools.ts
@@ -29,10 +29,11 @@ export interface Tool {
  *
  * Every tool returns a `raw` object whose `status` field signals outcome:
  *
- * | `raw.status`  | Source                                          | Meaning                                                                 |
- * |---------------|-------------------------------------------------|-------------------------------------------------------------------------|
- * | `'SUCCESS'`   | `coreAction` (query tools) or `ExecuteStrategy` | Operation completed successfully                                         |
- * | `'ERROR'`     | `BaseTool.handleError()` / `BaseTransactionTool.handleError()` | Caught exception. Transaction tools extend `BaseTransactionTool`, which additionally sets `raw.errorCode` (specific SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId` for Hedera receipt failures. |
+ * | `raw.status`    | Source                                          | Meaning                                                                 |
+ * |-----------------|-------------------------------------------------|-------------------------------------------------------------------------|
+ * | `'SUCCESS'`     | `coreAction` (query tools) or `ExecuteStrategy` | Operation completed successfully                                         |
+ * | `'ERROR'`       | `BaseTool.handleError()` / `BaseTransactionTool.handleError()` | Caught exception. Transaction tools extend `BaseTransactionTool`, which additionally sets `raw.errorCode` (specific SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId` for Hedera receipt failures. |
+ * | `'PARSE_ERROR'` | `transactionToolOutputParser` / `untypedQueryOutputParser` | Output is not valid JSON or has an unexpected shape.                     |
  *
  * Use {@link classifyToolResult} to map these into the stable
  * `ToolResultStatus` discriminated union (`success | failure | parse_error | unknown`).

--- a/packages/core/src/shared/tools.ts
+++ b/packages/core/src/shared/tools.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Client } from '@hiero-ledger/sdk';
 import { Context } from './configuration';
-import { TOOL_STATUS } from '@/shared/utils';
+import { TOOL_STATUS } from './utils/default-tool-output-parsing';
 
 import {
   PreToolExecutionParams,

--- a/packages/core/src/shared/tools.ts
+++ b/packages/core/src/shared/tools.ts
@@ -137,7 +137,7 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
     const desc = `Failed to execute ${this.name}`;
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error(`[${this.method}]`, message);
-    return { raw: { error: message }, humanMessage: message };
+    return { raw: { status: 'ERROR', error: message }, humanMessage: message };
   }
 
   // Abstract steps

--- a/packages/core/src/shared/tools.ts
+++ b/packages/core/src/shared/tools.ts
@@ -20,6 +20,23 @@ export interface Tool {
   outputParser?: (rawOutput: string) => { raw: any; humanMessage: string };
 }
 
+/**
+ * Base class for all Hedera Agent Kit tools. Subclasses implement the
+ * `coreAction` / `secondaryAction` pipeline and inherit a standard
+ * `{ raw, humanMessage }` output envelope.
+ *
+ * ## `raw.status` contract
+ *
+ * Every tool returns a `raw` object whose `status` field signals outcome:
+ *
+ * | `raw.status`  | Source                                          | Meaning                                                                 |
+ * |---------------|-------------------------------------------------|-------------------------------------------------------------------------|
+ * | `'SUCCESS'`   | `coreAction` (query tools) or `ExecuteStrategy` | Operation completed successfully                                         |
+ * | `'ERROR'`     | `BaseTool.handleError()` / `BaseTransactionTool.handleError()` | Caught exception. Transaction tools extend `BaseTransactionTool`, which additionally sets `raw.errorCode` (specific SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId` for Hedera receipt failures. |
+ *
+ * Use {@link classifyToolResult} to map these into the stable
+ * `ToolResultStatus` discriminated union (`success | failure | parse_error | unknown`).
+ */
 export abstract class BaseTool<TParams = any, TNormalisedParams = any> implements Tool {
   abstract method: string;
   abstract name: string;
@@ -133,6 +150,12 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
     }
   }
 
+  /**
+   * Default error handler called when any step of `execute()` throws.
+   * Returns `{ raw: { status: 'ERROR', error: string }, humanMessage: string }`.
+   * Transaction tools extend `BaseTransactionTool` which overrides this to
+   * additionally extract structured fields from `ReceiptStatusError`.
+   */
   async handleError(error: unknown, _context: Context): Promise<any> {
     const desc = `Failed to execute ${this.name}`;
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');

--- a/packages/core/src/shared/utils/base64-utils.ts
+++ b/packages/core/src/shared/utils/base64-utils.ts
@@ -3,10 +3,10 @@
  * @param base64 - The base64 string to convert.
  */
 export const base64ToUtf8 = (base64: string): string => {
-    const binaryString = atob(base64);
-    const bytes = new Uint8Array(binaryString.length);
-    for (let i = 0; i < binaryString.length; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-    }
-    return new TextDecoder().decode(bytes);
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
 };

--- a/packages/core/src/shared/utils/default-tool-output-parsing.ts
+++ b/packages/core/src/shared/utils/default-tool-output-parsing.ts
@@ -123,3 +123,96 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
     humanMessage: parsedObject.humanMessage,
   };
 };
+
+/**
+ * Discriminated union describing a tool result that has been classified into
+ * a stable success / failure / parse_error shape.
+ *
+ * - `success`: the underlying tool reported a non-error status. `data` exposes
+ *   the original `raw` payload typed as `T`. `transactionId` is lifted out
+ *   when present so consumers don't need to know which sub-field carries it.
+ * - `failure`: the tool surfaced an error — either an SDK `Status` object
+ *   (`raw.status` is an object with a numeric `_code`, e.g. `Status.InvalidTransaction`)
+ *   or an explicit `raw.error` string. `errorCode` is normalised to the
+ *   numeric SDK code when available, falling back to the string status.
+ * - `parse_error`: the upstream parser could not interpret the tool output
+ *   (`raw.status === 'PARSE_ERROR'`) or the envelope was malformed.
+ */
+export type ToolResultStatus<T = unknown> =
+  | { kind: 'success'; transactionId?: string; data: T; humanMessage: string }
+  | { kind: 'failure'; errorCode: number | string; error: string; humanMessage: string }
+  | { kind: 'parse_error'; originalOutput: unknown; humanMessage: string };
+
+/**
+ * Classify the `{ raw, humanMessage }` envelope returned by
+ * {@link transactionToolOutputParser} or {@link untypedQueryOutputParser}
+ * into a typed, discriminated `ToolResultStatus<T>`.
+ *
+ * This is an **additive, opt-in** helper. Existing parsers continue to return
+ * `{ raw: any; humanMessage: string }` unchanged. Consumers that want a
+ * single, type-safe surface for branching on success vs. failure can pass
+ * that envelope here and `switch` on `kind`.
+ *
+ * @example
+ * ```ts
+ * const envelope = transactionToolOutputParser(rawOutput);
+ * const result = classifyToolResult<{ transactionId: string; topicId?: string }>(envelope);
+ * switch (result.kind) {
+ *   case 'success':
+ *     return { txId: result.transactionId, topicId: result.data.topicId };
+ *   case 'failure':
+ *     throw new Error(`tool failed (${result.errorCode}): ${result.error}`);
+ *   case 'parse_error':
+ *     throw new Error(`tool output unparseable: ${result.humanMessage}`);
+ * }
+ * ```
+ *
+ * @param parsed The envelope returned by one of the default tool parsers.
+ * @returns A `ToolResultStatus<T>` tagged union safe to `switch` on.
+ */
+export const classifyToolResult = <T = unknown>(parsed: {
+  raw: any;
+  humanMessage: string;
+}): ToolResultStatus<T> => {
+  const humanMessage = parsed?.humanMessage ?? '';
+  const raw = parsed?.raw;
+
+  if (raw == null || typeof raw !== 'object') {
+    return {
+      kind: 'parse_error',
+      originalOutput: raw,
+      humanMessage: humanMessage || 'Error: Tool output had an unexpected format.',
+    };
+  }
+
+  if (raw.status === 'PARSE_ERROR') {
+    return {
+      kind: 'parse_error',
+      originalOutput: 'originalOutput' in raw ? raw.originalOutput : raw,
+      humanMessage,
+    };
+  }
+
+  const statusIsObject = raw.status !== null && typeof raw.status === 'object';
+  if (statusIsObject || typeof raw.error === 'string') {
+    const errorCode =
+      statusIsObject && '_code' in (raw.status as object)
+        ? (raw.status as { _code: number })._code
+        : typeof raw.status === 'string'
+          ? raw.status
+          : 'UNKNOWN';
+    return {
+      kind: 'failure',
+      errorCode,
+      error: typeof raw.error === 'string' ? raw.error : humanMessage,
+      humanMessage,
+    };
+  }
+
+  return {
+    kind: 'success',
+    transactionId: typeof raw.transactionId === 'string' ? raw.transactionId : undefined,
+    data: raw as T,
+    humanMessage,
+  };
+};

--- a/packages/core/src/shared/utils/default-tool-output-parsing.ts
+++ b/packages/core/src/shared/utils/default-tool-output-parsing.ts
@@ -1,4 +1,35 @@
 /**
+ * Shared status constants for the `raw.status` field.
+ *
+ * Using this object at every write site (instead of bare string literals) gives
+ * compile-time protection against typos
+ *
+ * | Value          | Set by                                                                                          |
+ * |----------------|-------------------------------------------------------------------------------------------------|
+ * | `SUCCESS`      | `BaseTool.execute()` (defaulted for any tool that reaches the end without an explicit status),  |
+ * |                | `ReturnBytesStrategy`, and `ExecuteStrategy` (receipt is always `SUCCESS` here — non-SUCCESS    |
+ * |                | receipts throw before the return).                                                              |
+ * | `ERROR`        | `BaseTransactionTool.handleError()` (receipt/precheck failures) or `BaseTool.handleError()`    |
+ * |                | (generic). Receipt/precheck failures additionally set `raw.errorCode` (SDK status name, e.g.   |
+ * |                | `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId`.                                        |
+ * | `PARSE_ERROR`  | `transactionToolOutputParser` / `untypedQueryOutputParser` when the output is malformed.        |
+ */
+export const TOOL_STATUS = {
+  SUCCESS: 'SUCCESS',
+  ERROR: 'ERROR',
+  PARSE_ERROR: 'PARSE_ERROR',
+} as const;
+
+/**
+ * Well-known string values that appear in `raw.status` across all tool outputs.
+ * Derived from {@link TOOL_STATUS} so the type and the runtime values are always in sync.
+ *
+ * Use {@link classifyToolResult} to map these into the stable
+ * `ToolResultStatus` discriminated union (`success | failure | parse_error | unknown`).
+ */
+export type ToolRawStatus = (typeof TOOL_STATUS)[keyof typeof TOOL_STATUS];
+
+/**
  * Parse a transaction tool's JSON output into a normalized shape.
  *
  * Accepts a stringified JSON `rawOutput` produced by a transaction tool and
@@ -28,7 +59,7 @@ export const transactionToolOutputParser = (
   } catch (error) {
     console.error(`[transactionToolOutputParser] Failed to parse JSON:`, rawOutput, error);
     return {
-      raw: { status: 'PARSE_ERROR', error: error, originalOutput: rawOutput },
+      raw: { status: TOOL_STATUS.PARSE_ERROR, error: error, originalOutput: rawOutput },
       humanMessage: 'Error: Failed to parse tool output. The output was malformed.',
     };
   }
@@ -62,7 +93,7 @@ export const transactionToolOutputParser = (
   // Fallback for anything else
   console.error(`[transactionToolOutputParser] Parsed object has unknown shape:`, parsedObject);
   return {
-    raw: { status: 'PARSE_ERROR', originalOutput: rawOutput, parsedObject },
+    raw: { status: TOOL_STATUS.PARSE_ERROR, originalOutput: rawOutput, parsedObject },
     humanMessage: 'Error: Parsed tool output had an unexpected format.',
   };
 };
@@ -90,7 +121,7 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
   } catch (error) {
     console.error(`untypedQueryOutputParser failed to parse JSON:`, error);
     return {
-      raw: { status: 'PARSE_ERROR', error: error, originalOutput: rawOutput },
+      raw: { status: TOOL_STATUS.PARSE_ERROR, error: error, originalOutput: rawOutput },
       humanMessage: 'Error: Failed to parse tool output. The output was malformed.',
     };
   }
@@ -107,7 +138,7 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
     );
     return {
       raw: {
-        status: 'PARSE_ERROR',
+        status: TOOL_STATUS.PARSE_ERROR,
         error: "Parsed object missing 'raw' or 'humanMessage'",
         originalOutput: rawOutput,
       },
@@ -125,17 +156,6 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
 };
 
 /**
- * Well-known string values that appear in `raw.status` across all tool outputs.
- *
- * | Value          | Set by                                                                                       |
- * |----------------|----------------------------------------------------------------------------------------------|
- * | `'SUCCESS'`    | `ReturnBytesStrategy`, query tool `coreAction` implementations, and `ExecuteStrategy` (receipt is always `SUCCESS` here — non-SUCCESS receipts throw before the return) |
- * | `'ERROR'`      | `BaseTransactionTool.handleError()` (receipt failures) or `BaseTool.handleError()` (generic). Receipt failures additionally set `raw.errorCode` (e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId`. |
- * | `'PARSE_ERROR'`| `transactionToolOutputParser` / `untypedQueryOutputParser` when the output is malformed      |
- */
-export type ToolRawStatus = 'SUCCESS' | 'ERROR' | 'PARSE_ERROR';
-
-/**
  * Discriminated union describing a tool result that has been classified into
  * a stable success / failure / parse_error / unknown shape.
  *
@@ -143,8 +163,9 @@ export type ToolRawStatus = 'SUCCESS' | 'ERROR' | 'PARSE_ERROR';
  *   payload typed as `T`. `transactionId` is lifted out when present.
  * - `failure`: `raw.status === 'ERROR'` or `raw.error` is a string. `errorCode`
  *   is the specific SDK status name (e.g. `'INSUFFICIENT_PAYER_BALANCE'`) when
- *   the failure was a Hedera network receipt error, or `'ERROR'` for generic
- *   caught exceptions.
+ *   the failure was a Hedera network receipt or precheck error, or `'ERROR'` for
+ *   generic caught exceptions. `transactionId` is lifted out when present
+ *   (receipt and precheck failures both set it).
  * - `parse_error`: `raw.status === 'PARSE_ERROR'` or the envelope was
  *   structurally malformed (missing `raw`, non-object, etc.).
  * - `unknown`: `raw.status` is a non-empty string that does not match any of
@@ -155,7 +176,13 @@ export type ToolRawStatus = 'SUCCESS' | 'ERROR' | 'PARSE_ERROR';
  */
 export type ToolResultStatus<T = unknown> =
   | { kind: 'success'; transactionId?: string; data: T; humanMessage: string }
-  | { kind: 'failure'; errorCode: number | string; error: string; humanMessage: string }
+  | {
+      kind: 'failure';
+      errorCode: string;
+      transactionId?: string;
+      error: string;
+      humanMessage: string;
+    }
   | { kind: 'parse_error'; originalOutput: unknown; humanMessage: string }
   | { kind: 'unknown'; humanMessage: string };
 
@@ -200,7 +227,7 @@ export const classifyToolResult = <T = unknown>(parsed: {
     };
   }
 
-  if (raw.status === 'PARSE_ERROR') {
+  if (raw.status === TOOL_STATUS.PARSE_ERROR) {
     return {
       kind: 'parse_error',
       originalOutput: 'originalOutput' in raw ? raw.originalOutput : raw,
@@ -208,7 +235,7 @@ export const classifyToolResult = <T = unknown>(parsed: {
     };
   }
 
-  if (raw.status === 'SUCCESS') {
+  if (raw.status === TOOL_STATUS.SUCCESS) {
     return {
       kind: 'success',
       transactionId: typeof raw.transactionId === 'string' ? raw.transactionId : undefined,
@@ -217,7 +244,7 @@ export const classifyToolResult = <T = unknown>(parsed: {
     };
   }
 
-  if (raw.status === 'ERROR' || typeof raw.error === 'string') {
+  if (raw.status === TOOL_STATUS.ERROR || typeof raw.error === 'string') {
     return {
       kind: 'failure',
       // Prefer raw.errorCode (SDK status name, e.g. 'INSUFFICIENT_PAYER_BALANCE')
@@ -228,6 +255,7 @@ export const classifyToolResult = <T = unknown>(parsed: {
           : typeof raw.status === 'string'
             ? raw.status
             : 'UNKNOWN',
+      transactionId: typeof raw.transactionId === 'string' ? raw.transactionId : undefined,
       error: typeof raw.error === 'string' ? raw.error : humanMessage,
       humanMessage,
     };

--- a/packages/core/src/shared/utils/default-tool-output-parsing.ts
+++ b/packages/core/src/shared/utils/default-tool-output-parsing.ts
@@ -125,18 +125,33 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
 };
 
 /**
- * Discriminated union describing a tool result that has been classified into
- * a stable success / failure / parse_error shape.
+ * Well-known string values that appear in `raw.status` across all tool outputs.
  *
- * - `success`: the underlying tool reported a non-error status. `data` exposes
- *   the original `raw` payload typed as `T`. `transactionId` is lifted out
- *   when present so consumers don't need to know which sub-field carries it.
- * - `failure`: the tool surfaced an error — either an SDK `Status` object
- *   (`raw.status` is an object with a numeric `_code`, e.g. `Status.InvalidTransaction`)
- *   or an explicit `raw.error` string. `errorCode` is normalised to the
- *   numeric SDK code when available, falling back to the string status.
- * - `parse_error`: the upstream parser could not interpret the tool output
- *   (`raw.status === 'PARSE_ERROR'`) or the envelope was malformed.
+ * | Value          | Set by                                                                                       |
+ * |----------------|----------------------------------------------------------------------------------------------|
+ * | `'SUCCESS'`    | `ReturnBytesStrategy`, query tool `coreAction` implementations, and `ExecuteStrategy` (receipt is always `SUCCESS` here — non-SUCCESS receipts throw before the return) |
+ * | `'ERROR'`      | `BaseTransactionTool.handleError()` (receipt failures) or `BaseTool.handleError()` (generic). Receipt failures additionally set `raw.errorCode` (e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId`. |
+ * | `'PARSE_ERROR'`| `transactionToolOutputParser` / `untypedQueryOutputParser` when the output is malformed      |
+ */
+export type ToolRawStatus = 'SUCCESS' | 'ERROR' | 'PARSE_ERROR';
+
+/**
+ * Discriminated union describing a tool result that has been classified into
+ * a stable success / failure / parse_error / unknown shape.
+ *
+ * - `success`: `raw.status === 'SUCCESS'`. `data` exposes the original `raw`
+ *   payload typed as `T`. `transactionId` is lifted out when present.
+ * - `failure`: `raw.status === 'ERROR'` or `raw.error` is a string. `errorCode`
+ *   is the specific SDK status name (e.g. `'INSUFFICIENT_PAYER_BALANCE'`) when
+ *   the failure was a Hedera network receipt error, or `'ERROR'` for generic
+ *   caught exceptions.
+ * - `parse_error`: `raw.status === 'PARSE_ERROR'` or the envelope was
+ *   structurally malformed (missing `raw`, non-object, etc.).
+ * - `unknown`: `raw.status` is a non-empty string that does not match any of
+ *   the above (e.g. an unexpected Hedera SDK status from `ExecuteStrategy`).
+ *
+ * See {@link ToolRawStatus} for the known `raw.status` string values and
+ * {@link BaseTool} for the full `raw.status` contract.
  */
 export type ToolResultStatus<T = unknown> =
   | { kind: 'success'; transactionId?: string; data: T; humanMessage: string }
@@ -205,7 +220,14 @@ export const classifyToolResult = <T = unknown>(parsed: {
   if (raw.status === 'ERROR' || typeof raw.error === 'string') {
     return {
       kind: 'failure',
-      errorCode: typeof raw.status === 'string' ? raw.status : 'UNKNOWN',
+      // Prefer raw.errorCode (SDK status name, e.g. 'INSUFFICIENT_PAYER_BALANCE')
+      // when present; fall back to raw.status ('ERROR') for generic errors.
+      errorCode:
+        typeof raw.errorCode === 'string'
+          ? raw.errorCode
+          : typeof raw.status === 'string'
+            ? raw.status
+            : 'UNKNOWN',
       error: typeof raw.error === 'string' ? raw.error : humanMessage,
       humanMessage,
     };

--- a/packages/core/src/shared/utils/default-tool-output-parsing.ts
+++ b/packages/core/src/shared/utils/default-tool-output-parsing.ts
@@ -141,7 +141,8 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
 export type ToolResultStatus<T = unknown> =
   | { kind: 'success'; transactionId?: string; data: T; humanMessage: string }
   | { kind: 'failure'; errorCode: number | string; error: string; humanMessage: string }
-  | { kind: 'parse_error'; originalOutput: unknown; humanMessage: string };
+  | { kind: 'parse_error'; originalOutput: unknown; humanMessage: string }
+  | { kind: 'unknown'; humanMessage: string };
 
 /**
  * Classify the `{ raw, humanMessage }` envelope returned by
@@ -174,8 +175,7 @@ export const classifyToolResult = <T = unknown>(parsed: {
   raw: any;
   humanMessage: string;
 }): ToolResultStatus<T> => {
-  const humanMessage = parsed?.humanMessage ?? '';
-  const raw = parsed?.raw;
+  const { raw, humanMessage } = parsed;
 
   if (raw == null || typeof raw !== 'object') {
     return {
@@ -193,26 +193,23 @@ export const classifyToolResult = <T = unknown>(parsed: {
     };
   }
 
-  const statusIsObject = raw.status !== null && typeof raw.status === 'object';
-  if (statusIsObject || typeof raw.error === 'string') {
-    const errorCode =
-      statusIsObject && '_code' in (raw.status as object)
-        ? (raw.status as { _code: number })._code
-        : typeof raw.status === 'string'
-          ? raw.status
-          : 'UNKNOWN';
+  if (raw.status === 'SUCCESS') {
+    return {
+      kind: 'success',
+      transactionId: typeof raw.transactionId === 'string' ? raw.transactionId : undefined,
+      data: raw as T,
+      humanMessage,
+    };
+  }
+
+  if (raw.status === 'ERROR' || typeof raw.error === 'string') {
     return {
       kind: 'failure',
-      errorCode,
+      errorCode: typeof raw.status === 'string' ? raw.status : 'UNKNOWN',
       error: typeof raw.error === 'string' ? raw.error : humanMessage,
       humanMessage,
     };
   }
 
-  return {
-    kind: 'success',
-    transactionId: typeof raw.transactionId === 'string' ? raw.transactionId : undefined,
-    data: raw as T,
-    humanMessage,
-  };
+  return { kind: 'unknown', humanMessage };
 };

--- a/packages/core/src/shared/utils/index.ts
+++ b/packages/core/src/shared/utils/index.ts
@@ -2,3 +2,5 @@ export { AccountResolver } from './account-resolver';
 export { PromptGenerator } from './prompt-generator';
 export { transactionToolOutputParser } from './default-tool-output-parsing';
 export { untypedQueryOutputParser } from './default-tool-output-parsing';
+export { classifyToolResult } from './default-tool-output-parsing';
+export type { ToolResultStatus } from './default-tool-output-parsing';

--- a/packages/core/src/shared/utils/index.ts
+++ b/packages/core/src/shared/utils/index.ts
@@ -3,4 +3,4 @@ export { PromptGenerator } from './prompt-generator';
 export { transactionToolOutputParser } from './default-tool-output-parsing';
 export { untypedQueryOutputParser } from './default-tool-output-parsing';
 export { classifyToolResult } from './default-tool-output-parsing';
-export type { ToolResultStatus } from './default-tool-output-parsing';
+export type { ToolResultStatus, ToolRawStatus } from './default-tool-output-parsing';

--- a/packages/core/src/shared/utils/index.ts
+++ b/packages/core/src/shared/utils/index.ts
@@ -3,4 +3,5 @@ export { PromptGenerator } from './prompt-generator';
 export { transactionToolOutputParser } from './default-tool-output-parsing';
 export { untypedQueryOutputParser } from './default-tool-output-parsing';
 export { classifyToolResult } from './default-tool-output-parsing';
+export { TOOL_STATUS } from './default-tool-output-parsing';
 export type { ToolResultStatus, ToolRawStatus } from './default-tool-output-parsing';

--- a/packages/core/tests/integration/hedera/airdrop-fungible-token.integration.test.ts
+++ b/packages/core/tests/integration/hedera/airdrop-fungible-token.integration.test.ts
@@ -153,6 +153,9 @@ describe('Airdrop Fungible Token Integration Tests', () => {
 
     const result: any = await tool.execute(executorClient, context, params);
 
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.errorCode).toBe('INSUFFICIENT_TOKEN_BALANCE');
+    expect(result.raw.transactionId).toBeDefined();
     expect(result.raw.error).toContain('INSUFFICIENT_TOKEN_BALANCE');
 
     recipientClient.close();

--- a/packages/core/tests/integration/hedera/create-erc20.integration.test.ts
+++ b/packages/core/tests/integration/hedera/create-erc20.integration.test.ts
@@ -100,8 +100,8 @@ describe('Create ERC20 Integration Tests', () => {
       expect(result.raw.error).toContain(
         'Invalid parameters: Field "tokenName" - Required; Field "tokenSymbol" - Required',
       );
-      expect(result.raw.error).toContain('Failed to create ERC20 token');
-      expect(result.humanMessage).toContain('Failed to create ERC20 token');
+      expect(result.raw.error).toContain('Failed to execute Create ERC20 Token');
+      expect(result.humanMessage).toContain('Failed to execute Create ERC20 Token');
     });
 
     it('should fail when decimals is invalid', async () => {
@@ -115,8 +115,8 @@ describe('Create ERC20 Integration Tests', () => {
       const tool = createERC20Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.raw.error).toContain('Failed to create ERC20 token');
-      expect(result.humanMessage).toContain('Failed to create ERC20 token');
+      expect(result.raw.error).toContain('Failed to execute Create ERC20 Token');
+      expect(result.humanMessage).toContain('Failed to execute Create ERC20 Token');
 
       expect(result.raw.error).toContain(
         'Invalid parameters: Field "decimals" - Number must be greater than or equal to 0',

--- a/packages/core/tests/integration/hedera/create-erc721.integration.test.ts
+++ b/packages/core/tests/integration/hedera/create-erc721.integration.test.ts
@@ -115,8 +115,8 @@ describe('Create ERC721 Integration Tests', () => {
       expect(result.raw.error).toContain(
         'Invalid parameters: Field "tokenName" - Required; Field "tokenSymbol" - Required',
       );
-      expect(result.raw.error).toContain('Failed to create ERC721 token');
-      expect(result.humanMessage).toContain('Failed to create ERC721 token');
+      expect(result.raw.error).toContain('Failed to execute Create ERC721 Token');
+      expect(result.humanMessage).toContain('Failed to execute Create ERC721 Token');
     });
 
     it('should fail when tokenName is invalid type', async () => {
@@ -129,8 +129,8 @@ describe('Create ERC721 Integration Tests', () => {
       const tool = createERC721Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.raw.error).toContain('Failed to create ERC721 token');
-      expect(result.humanMessage).toContain('Failed to create ERC721 token');
+      expect(result.raw.error).toContain('Failed to execute Create ERC721 Token');
+      expect(result.humanMessage).toContain('Failed to execute Create ERC721 Token');
 
       expect(result.raw.error).toContain('Invalid parameters: Field "tokenName"');
       expect(result.humanMessage).toContain('Invalid parameters: Field "tokenName"');
@@ -146,8 +146,8 @@ describe('Create ERC721 Integration Tests', () => {
       const tool = createERC721Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.raw.error).toContain('Failed to create ERC721 token');
-      expect(result.humanMessage).toContain('Failed to create ERC721 token');
+      expect(result.raw.error).toContain('Failed to execute Create ERC721 Token');
+      expect(result.humanMessage).toContain('Failed to execute Create ERC721 Token');
 
       expect(result.raw.error).toContain('Invalid parameters: Field "baseURI"');
       expect(result.humanMessage).toContain('Invalid parameters: Field "baseURI"');

--- a/packages/core/tests/integration/hedera/delete-account.integration.test.ts
+++ b/packages/core/tests/integration/hedera/delete-account.integration.test.ts
@@ -95,8 +95,10 @@ describe('Delete Account Integration Tests', () => {
       const result: any = await tool.execute(executorClient, context, params);
 
       expect(result.humanMessage).toMatch(/INVALID_ACCOUNT_ID/i);
+      expect(result.raw.status).toBe('ERROR');
+      expect(result.raw.errorCode).toMatch(/INVALID_ACCOUNT_ID/i);
+      expect(result.raw.transactionId).toBeDefined();
       expect(result.raw.error).toMatch(/INVALID_ACCOUNT_ID/i);
-      expect(result.raw.status).not.toBe('SUCCESS');
     });
   });
 });

--- a/packages/core/tests/integration/hedera/delete-topic.integration.test.ts
+++ b/packages/core/tests/integration/hedera/delete-topic.integration.test.ts
@@ -50,7 +50,7 @@ describe('Delete Topic Integration Tests', () => {
     const tool = deleteTopicTool(context);
     const result: any = await tool.execute(executorClient, context, params);
 
-    expect(result.humanMessage).toContain('Failed to delete the topic');
+    expect(result.humanMessage).toContain('Failed to execute Delete Topic');
     expect(result.raw.status).toBeDefined();
   });
 });

--- a/packages/core/tests/integration/hedera/dissociate-token.integration.test.ts
+++ b/packages/core/tests/integration/hedera/dissociate-token.integration.test.ts
@@ -140,8 +140,10 @@ describe('Dissociate Token Integration Tests', () => {
     };
 
     const result: any = await tool.execute(executorClient, context, params);
-    expect(result.humanMessage).toContain('Failed to dissociate');
-    expect(result.raw.status).not.toBe('SUCCESS');
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.errorCode).toBe('TOKEN_NOT_ASSOCIATED_TO_ACCOUNT');
+    expect(result.raw.transactionId).toBeDefined();
+    expect(result.humanMessage).toContain('Failed to execute Dissociate Token');
   });
 
   it('should fail dissociating a non-existent token', async () => {
@@ -151,7 +153,9 @@ describe('Dissociate Token Integration Tests', () => {
     };
 
     const result: any = await tool.execute(executorClient, context, params);
-    expect(result.humanMessage).toContain('Failed to dissociate');
-    expect(result.raw.status).not.toBe('SUCCESS');
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.errorCode).toBe('TOKEN_NOT_ASSOCIATED_TO_ACCOUNT');
+    expect(result.raw.transactionId).toBeDefined();
+    expect(result.humanMessage).toContain('Failed to execute Dissociate Token');
   });
 });

--- a/packages/core/tests/integration/hedera/get-account-token-balances.integration.test.ts
+++ b/packages/core/tests/integration/hedera/get-account-token-balances.integration.test.ts
@@ -218,8 +218,8 @@ describe('Integration - Hedera getTransactionRecord', () => {
     });
 
     expect(resp.humanMessage).toContain('Not Found');
-    expect(resp.humanMessage).toContain('Failed to get account token balances');
-    expect(resp.raw.error).toContain('Failed to get account token balances');
+    expect(resp.humanMessage).toContain('Failed to execute Get Account Token Balances');
+    expect(resp.raw.error).toContain('Failed to execute Get Account Token Balances');
   });
 
   it('handles account with no token associations', async () => {
@@ -341,8 +341,8 @@ describe('Integration - Hedera getTransactionRecord', () => {
     });
 
     expect(resp.humanMessage).toContain('400 Bad Request');
-    expect(resp.humanMessage).toContain('Failed to get account token balances');
-    expect(resp.raw.error).toContain('Failed to get account token balances');
+    expect(resp.humanMessage).toContain('Failed to execute Get Account Token Balances');
+    expect(resp.raw.error).toContain('Failed to execute Get Account Token Balances');
   });
 
   it('handles zero token balance correctly', async () => {

--- a/packages/core/tests/integration/hedera/get-contract-info-query.integration.test.ts
+++ b/packages/core/tests/integration/hedera/get-contract-info-query.integration.test.ts
@@ -61,8 +61,8 @@ describe('Integration - Hedera Get Contract Info', () => {
     });
 
     expect(result.raw.contractInfo).toBeUndefined();
-    expect(result.raw.error).toContain('Failed to get contract info');
-    expect(result.humanMessage).toContain('Failed to get contract info');
+    expect(result.raw.error).toContain('Failed to execute Get Contract Info');
+    expect(result.humanMessage).toContain('Failed to execute Get Contract Info');
   });
 
   afterAll(async () => {

--- a/packages/core/tests/integration/hedera/get-exchange-rate.integration.test.ts
+++ b/packages/core/tests/integration/hedera/get-exchange-rate.integration.test.ts
@@ -84,8 +84,8 @@ describe('Get Exchange Rate', () => {
 
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(
-      '[GetExchangeRate] Error getting exchange rate',
-      expect.objectContaining({ message: expect.stringContaining('HTTP error! status: 400') }),
+      '[get_exchange_rate_tool]',
+      expect.stringContaining('Failed to execute Get Exchange Rate: HTTP error! status: 400'),
     );
   });
 });

--- a/packages/core/tests/integration/hedera/get-hbar-balance.integration.test.ts
+++ b/packages/core/tests/integration/hedera/get-hbar-balance.integration.test.ts
@@ -86,6 +86,6 @@ describe('Get HBAR Balance Integration Tests (Executor Account)', () => {
     });
     const res: any = await tool.execute(executorClient, context, params);
 
-    expect(res.humanMessage).toContain('Failed to get HBAR balance');
+    expect(res.humanMessage).toContain('Failed to execute Get HBAR Balance');
   });
 });

--- a/packages/core/tests/integration/hedera/get-token-info-query.integration.test.ts
+++ b/packages/core/tests/integration/hedera/get-token-info-query.integration.test.ts
@@ -162,7 +162,7 @@ describe('Get Token Info Query Integration Tests', () => {
 
     const result: any = await tool.execute(executorClient, context, params);
 
-    expect(result.humanMessage).toContain('Failed to get token info');
+    expect(result.humanMessage).toContain('Failed to execute Get Token Info');
     expect(result.raw.error).toBeDefined();
   });
 

--- a/packages/core/tests/integration/hedera/get-topic-info.integration.test.ts
+++ b/packages/core/tests/integration/hedera/get-topic-info.integration.test.ts
@@ -68,7 +68,7 @@ describe('Get Topic Info Query Integration Tests', () => {
       topicId: '0.0.999999999',
     });
 
-    expect(result.humanMessage).toContain('Failed to get topic info');
+    expect(result.humanMessage).toContain('Failed to execute Get Topic Info');
   });
 
   afterEach(async () => {

--- a/packages/core/tests/integration/hedera/get-transaction-record.integration.test.ts
+++ b/packages/core/tests/integration/hedera/get-transaction-record.integration.test.ts
@@ -63,7 +63,7 @@ describe('Integration - Hedera getTransactionRecord', () => {
       transactionId: 'not-a-valid-id',
     });
 
-    expect(response.humanMessage).toContain('Failed to get transaction record');
+    expect(response.humanMessage).toContain('Failed to execute Get Transaction Record Query');
     expect(response.humanMessage).toContain('Invalid transactionId format');
   });
 

--- a/packages/core/tests/integration/hedera/mint-erc721.integration.test.ts
+++ b/packages/core/tests/integration/hedera/mint-erc721.integration.test.ts
@@ -122,7 +122,7 @@ describe('Mint ERC721 Integration Tests', () => {
       const tool = mintERC721Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.humanMessage).toContain('Failed to mint ERC721');
+      expect(result.humanMessage).toContain('Failed to execute Mint ERC721');
       expect(result.raw.error).toContain('Invalid parameters');
     });
 
@@ -134,8 +134,8 @@ describe('Mint ERC721 Integration Tests', () => {
       const tool = mintERC721Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.humanMessage).toContain('Failed to mint ERC721');
-      expect(result.raw.error).toContain('Failed to mint ERC721');
+      expect(result.humanMessage).toContain('Failed to execute Mint ERC721');
+      expect(result.raw.error).toContain('Failed to execute Mint ERC721');
     });
   });
 });

--- a/packages/core/tests/integration/hedera/mint-fungible-token.integration.test.ts
+++ b/packages/core/tests/integration/hedera/mint-fungible-token.integration.test.ts
@@ -108,6 +108,9 @@ describe('Mint Fungible Token Integration Tests', () => {
     const result: any = await tool.execute(executorClient, context, params);
 
     expect(result.raw).toBeDefined();
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.errorCode).toBe('TOKEN_MAX_SUPPLY_REACHED');
+    expect(result.raw.transactionId).toBeDefined();
     expect(result.raw.error).toContain('TOKEN_MAX_SUPPLY_REACHED');
   });
 
@@ -121,6 +124,6 @@ describe('Mint Fungible Token Integration Tests', () => {
     const result: any = await tool.execute(executorClient, context, params);
 
     expect(result.humanMessage).toContain('Not Found');
-    expect(result.humanMessage).toContain('Failed to mint fungible token');
+    expect(result.humanMessage).toContain('Failed to execute Mint Fungible Token');
   });
 });

--- a/packages/core/tests/integration/hedera/mint-non-fungible-token.integraion.test.ts
+++ b/packages/core/tests/integration/hedera/mint-non-fungible-token.integraion.test.ts
@@ -139,6 +139,9 @@ describe('Mint Non-Fungible Token Integration Tests', () => {
     const result: any = await tool.execute(executorClient, context, params);
 
     expect(result).toBeDefined();
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.errorCode).toBe('INVALID_TOKEN_ID');
+    expect(result.raw.transactionId).toBeDefined();
     expect(result.humanMessage).toContain('INVALID_TOKEN_ID');
     expect(result.raw.error).toContain('INVALID_TOKEN_ID');
   });

--- a/packages/core/tests/integration/hedera/schedule-delete.integration.test.ts
+++ b/packages/core/tests/integration/hedera/schedule-delete.integration.test.ts
@@ -91,8 +91,10 @@ describe('Schedule Delete Integration Tests', () => {
       const tool = scheduleDeleteTool(context);
       const result = await tool.execute(operatorClient, context, params);
 
-      expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to delete scheduled transaction');
+      expect(result.raw.status).toBe('ERROR');
+      expect(result.raw.errorCode).toBe('INVALID_SCHEDULE_ID');
+      expect(result.raw.transactionId).toBeDefined();
+      expect(result.humanMessage).toContain('Failed to execute Delete Scheduled Transaction');
     });
 
     it('should fail with malformed schedule ID', async () => {
@@ -104,7 +106,7 @@ describe('Schedule Delete Integration Tests', () => {
       const result = await tool.execute(operatorClient, context, params);
 
       expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to delete scheduled transaction');
+      expect(result.humanMessage).toContain('Failed to execute Delete Scheduled Transaction');
     });
   });
 });

--- a/packages/core/tests/integration/hedera/sign-schedule-transaction.integration.test.ts
+++ b/packages/core/tests/integration/hedera/sign-schedule-transaction.integration.test.ts
@@ -125,8 +125,10 @@ describe('Sign Schedule Transaction Integration Tests', () => {
       const result = await tool.execute(executorClient, context, params);
 
       // Should return an error
-      expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to sign scheduled transaction');
+      expect(result.raw.status).toBe('ERROR');
+      expect(result.raw.errorCode).toBe('INVALID_SCHEDULE_ID');
+      expect(result.raw.transactionId).toBeDefined();
+      expect(result.humanMessage).toContain('Failed to execute Sign Scheduled Transaction');
     });
 
     it('should fail with malformed schedule ID', async () => {
@@ -139,7 +141,7 @@ describe('Sign Schedule Transaction Integration Tests', () => {
 
       // Should return an error
       expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to sign scheduled transaction');
+      expect(result.humanMessage).toContain('Failed to execute Sign Scheduled Transaction');
     });
 
     it('should fail with empty schedule ID', async () => {
@@ -152,7 +154,7 @@ describe('Sign Schedule Transaction Integration Tests', () => {
 
       // Should return an error
       expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to sign scheduled transaction');
+      expect(result.humanMessage).toContain('Failed to execute Sign Scheduled Transaction');
     });
 
     it('should fail when trying to sign already executed schedule', async () => {
@@ -192,8 +194,10 @@ describe('Sign Schedule Transaction Integration Tests', () => {
       const secondResult = await tool.execute(executorClient, context, params);
 
       // Should return an error since the schedule is already executed
-      expect(secondResult.raw.status).not.toBe('SUCCESS');
-      expect(secondResult.humanMessage).toContain('Failed to sign scheduled transaction');
+      expect(secondResult.raw.status).toBe('ERROR');
+      expect(secondResult.raw.errorCode).toBe('SCHEDULE_ALREADY_EXECUTED');
+      expect(secondResult.raw.transactionId).toBeDefined();
+      expect(secondResult.humanMessage).toContain('Failed to execute Sign Scheduled Transaction');
     });
   });
 
@@ -209,7 +213,7 @@ describe('Sign Schedule Transaction Integration Tests', () => {
 
       // Should return an error since this is not a valid schedule ID
       expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to sign scheduled transaction');
+      expect(result.humanMessage).toContain('Failed to execute Sign Scheduled Transaction');
     });
 
     it('should handle schedule ID with special characters', async () => {
@@ -223,7 +227,7 @@ describe('Sign Schedule Transaction Integration Tests', () => {
 
       // Should return an error since this is not a valid schedule ID
       expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to sign scheduled transaction');
+      expect(result.humanMessage).toContain('Failed to execute Sign Scheduled Transaction');
     });
   });
 });

--- a/packages/core/tests/integration/hedera/transfer-erc20.integration.test.ts
+++ b/packages/core/tests/integration/hedera/transfer-erc20.integration.test.ts
@@ -162,8 +162,8 @@ describe('Transfer ERC20 Integration Tests', () => {
       const tool = transferERC20Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.humanMessage).toContain('Failed to transfer ERC20');
-      expect(result.raw.error).toContain('Failed to transfer ERC20');
+      expect(result.humanMessage).toContain('Failed to execute Transfer ERC20');
+      expect(result.raw.error).toContain('Failed to execute Transfer ERC20');
       expect(result.raw.error).toContain('Invalid parameters');
     });
 
@@ -177,8 +177,8 @@ describe('Transfer ERC20 Integration Tests', () => {
       const tool = transferERC20Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.raw.error).toContain('Failed to transfer ERC20');
-      expect(result.humanMessage).toContain('Failed to transfer ERC20');
+      expect(result.raw.error).toContain('Failed to execute Transfer ERC20');
+      expect(result.humanMessage).toContain('Failed to execute Transfer ERC20');
     });
 
     it('should fail when amount is negative', async () => {
@@ -194,8 +194,8 @@ describe('Transfer ERC20 Integration Tests', () => {
       const tool = transferERC20Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.raw.error).toContain('Failed to transfer ERC20');
-      expect(result.humanMessage).toContain('Failed to transfer ERC20');
+      expect(result.raw.error).toContain('Failed to execute Transfer ERC20');
+      expect(result.humanMessage).toContain('Failed to execute Transfer ERC20');
     });
 
     it('should fail when recipientAddress is invalid', async () => {
@@ -208,8 +208,8 @@ describe('Transfer ERC20 Integration Tests', () => {
       const tool = transferERC20Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.raw.error).toContain('Failed to transfer ERC20');
-      expect(result.humanMessage).toContain('Failed to transfer ERC20');
+      expect(result.raw.error).toContain('Failed to execute Transfer ERC20');
+      expect(result.humanMessage).toContain('Failed to execute Transfer ERC20');
     });
   });
 });

--- a/packages/core/tests/integration/hedera/transfer-erc721.integration.test.ts
+++ b/packages/core/tests/integration/hedera/transfer-erc721.integration.test.ts
@@ -152,7 +152,7 @@ describe('Transfer ERC721 Integration Tests', () => {
       const tool = transferERC721Tool(context);
       const result: any = await tool.execute(executorClient, context, {} as any);
 
-      expect(result.humanMessage).toContain('Failed to transfer ERC721');
+      expect(result.humanMessage).toContain('Failed to execute Transfer ERC721');
       expect(result.raw.error).toContain('Invalid parameters');
     });
 
@@ -165,7 +165,7 @@ describe('Transfer ERC721 Integration Tests', () => {
       const tool = transferERC721Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.humanMessage).toContain('Failed to transfer ERC721');
+      expect(result.humanMessage).toContain('Failed to execute Transfer ERC721');
     });
 
     it('should fail when transferring non-existent token', async () => {
@@ -179,7 +179,7 @@ describe('Transfer ERC721 Integration Tests', () => {
       const tool = transferERC721Tool(context);
       const result: any = await tool.execute(executorClient, context, params);
 
-      expect(result.humanMessage).toContain('Failed to transfer ERC721');
+      expect(result.humanMessage).toContain('Failed to execute Transfer ERC721');
     });
   });
 });

--- a/packages/core/tests/integration/hedera/transfer-fungible-token-with-allowance.integration.test.ts
+++ b/packages/core/tests/integration/hedera/transfer-fungible-token-with-allowance.integration.test.ts
@@ -205,7 +205,10 @@ describe('Transfer Fungible Token With Allowance Tool Integration', () => {
 
     const result: any = await tool.execute(spenderClient, context, params);
 
-    expect(result.humanMessage).toContain('Failed to transfer fungible token with allowance');
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.errorCode).toBe('AMOUNT_EXCEEDS_ALLOWANCE');
+    expect(result.raw.transactionId).toBeDefined();
+    expect(result.humanMessage).toContain('Failed to execute Transfer Fungible Token with Allowance');
     expect(result.humanMessage).toContain('AMOUNT_EXCEEDS_ALLOWANCE');
   });
 });

--- a/packages/core/tests/integration/hedera/transfer-hbar-with-allowance.integration.test.ts
+++ b/packages/core/tests/integration/hedera/transfer-hbar-with-allowance.integration.test.ts
@@ -119,8 +119,10 @@ describe('Transfer HBAR With Allowance Integration Tests', () => {
       const tool = transferHbarWithAllowanceTool(context);
       const result = await tool.execute(spenderClient, context, params);
 
-      expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to transfer HBAR');
+      expect(result.raw.status).toBe('ERROR');
+      expect(result.raw.errorCode).toBe('SPENDER_DOES_NOT_HAVE_ALLOWANCE');
+      expect(result.raw.transactionId).toBeDefined();
+      expect(result.humanMessage).toContain('Failed to execute Transfer HBAR with allowance');
     });
 
     it('should fail when transfer exceeds approved allowance', async () => {
@@ -142,8 +144,10 @@ describe('Transfer HBAR With Allowance Integration Tests', () => {
       const tool = transferHbarWithAllowanceTool(context);
       const result = await tool.execute(spenderClient, context, params);
 
-      expect(result.raw.status).not.toBe('SUCCESS');
-      expect(result.humanMessage).toContain('Failed to transfer HBAR');
+      expect(result.raw.status).toBe('ERROR');
+      expect(result.raw.errorCode).toBe('AMOUNT_EXCEEDS_ALLOWANCE');
+      expect(result.raw.transactionId).toBeDefined();
+      expect(result.humanMessage).toContain('Failed to execute Transfer HBAR with allowance');
     });
 
     it('should fail if amount is zero or negative', async () => {

--- a/packages/core/tests/integration/hedera/transfer-non-fungible-token.integration.test.ts
+++ b/packages/core/tests/integration/hedera/transfer-non-fungible-token.integration.test.ts
@@ -129,8 +129,10 @@ describe('Transfer NFT Integration Tests', () => {
     const tool = transferNonFungibleToken(recipientContext);
     const result = await tool.execute(recipientClient, recipientContext, params);
 
-    expect(result.raw.status).not.toBe('SUCCESS');
-    expect(result.humanMessage).toContain('Failed to transfer non-fungible token');
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.errorCode).toBe('INVALID_NFT_ID');
+    expect(result.raw.transactionId).toBeDefined();
+    expect(result.humanMessage).toContain('Failed to execute Transfer Non Fungible Token');
   });
 
   it('should schedule an NFT transfer', async () => {

--- a/packages/core/tests/integration/hedera/update-token.integration.test.ts
+++ b/packages/core/tests/integration/hedera/update-token.integration.test.ts
@@ -154,7 +154,7 @@ describe('Update Token Integration Tests', () => {
     const result: any = await tool.execute(executorClient, context, params);
 
     expect(result.humanMessage).toContain(
-      'Failed to update token: Cannot update metadataKey: token was created without a metadataKey',
+      'Failed to execute Update Token: Cannot update metadataKey: token was created without a metadataKey',
     );
   });
 
@@ -164,7 +164,7 @@ describe('Update Token Integration Tests', () => {
 
     const result: any = await tool.execute(executorClient, context, params);
 
-    expect(result.humanMessage).toContain('Failed to update token:');
+    expect(result.humanMessage).toContain('Failed to execute Update Token:');
     expect(result.humanMessage).toContain('Not Found');
   });
 
@@ -277,7 +277,7 @@ describe('Update Token Integration Tests', () => {
     const params = { topicId: topicId.toString(), submitKey: true };
 
     const result: any = await tool.execute(executorClient, context, params);
-    expect(result.humanMessage).toContain('Failed to update topic: Cannot update submitKey');
+    expect(result.humanMessage).toContain('Failed to execute Update Topic: Cannot update submitKey');
   });
 
   it('fails with invalid topic ID', async () => {
@@ -285,6 +285,6 @@ describe('Update Token Integration Tests', () => {
     const params = { topicId: '0.0.999999999', topicMemo: 'Invalid topic' };
 
     const result: any = await tool.execute(executorClient, context, params);
-    expect(result.humanMessage).toContain('Failed to update topic:');
+    expect(result.humanMessage).toContain('Failed to execute Update Topic:');
   });
 });

--- a/packages/core/tests/integration/policy/reject-tool-policy.integration.test.ts
+++ b/packages/core/tests/integration/policy/reject-tool-policy.integration.test.ts
@@ -33,6 +33,7 @@ describe('reject tool policy integration tests', () => {
     await expect(tool.execute(operatorClient, context, params)).resolves.toEqual({
       raw: {
         error: `Failed to get HBAR balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`,
+        status: 'ERROR',
       },
       humanMessage: `Failed to get HBAR balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`,
     });

--- a/packages/core/tests/integration/policy/reject-tool-policy.integration.test.ts
+++ b/packages/core/tests/integration/policy/reject-tool-policy.integration.test.ts
@@ -32,10 +32,10 @@ describe('reject tool policy integration tests', () => {
 
     await expect(tool.execute(operatorClient, context, params)).resolves.toEqual({
       raw: {
-        error: `Failed to get HBAR balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`,
+        error: `Failed to execute Get HBAR Balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`,
         status: 'ERROR',
       },
-      humanMessage: `Failed to get HBAR balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`,
+      humanMessage: `Failed to execute Get HBAR Balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`,
     });
   });
 

--- a/packages/core/tests/unit/tools/associate-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/associate-token.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client} from '@hiero-ledger/sdk';
 import toolFactory, { ASSOCIATE_TOKEN_TOOL } from '@/plugins/core-token-plugin/tools/associate-token';
 import z from 'zod';
 import { associateTokenParameters } from '@/shared/parameter-schemas/token.zod';
@@ -112,7 +112,7 @@ describe('associate-token tool (unit)', () => {
     expect(res.humanMessage).toContain('boom');
     expect(res.raw.error).toContain('Failed to associate token');
     expect(res.raw.error).toContain('boom');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns aligned generic failure response when a non-Error is thrown', async () => {

--- a/packages/core/tests/unit/tools/associate-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/associate-token.unit.test.ts
@@ -108,9 +108,9 @@ describe('associate-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to associate token');
+    expect(res.humanMessage).toContain('Failed to execute Associate Token(s)');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to associate token');
+    expect(res.raw.error).toContain('Failed to execute Associate Token(s)');
     expect(res.raw.error).toContain('boom');
     expect(res.raw.status).toBe('ERROR');
   });
@@ -124,7 +124,7 @@ describe('associate-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toBe('Failed to associate token(s)');
-    expect(res.raw.error).toBe('Failed to associate token(s)');
+    expect(res.humanMessage).toBe('Failed to execute Associate Token(s)');
+    expect(res.raw.error).toBe('Failed to execute Associate Token(s)');
   });
 });

--- a/packages/core/tests/unit/tools/base-transaction-tool.unit.test.ts
+++ b/packages/core/tests/unit/tools/base-transaction-tool.unit.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { AccountId, ReceiptStatusError, Status, TransactionId } from '@hiero-ledger/sdk';
+import { BaseTransactionTool } from '@/shared/base-transaction-tool';
+import { Context } from '@/shared/configuration';
+import { z } from 'zod';
+
+// Minimal concrete subclass used only for testing BaseTransactionTool behaviour.
+class StubTransactionTool extends BaseTransactionTool {
+  method = 'stub_transaction_tool';
+  name = 'Stub Transaction Tool';
+  description = 'test stub';
+  parameters = z.object({});
+  async normalizeParams(p: any) { return p; }
+  async coreAction() { return {}; }
+  async secondaryAction(r: any) { return r; }
+}
+
+function makeReceiptStatusError(statusValue: Status): ReceiptStatusError {
+  const txId = TransactionId.generate(new AccountId(0, 0, 1));
+  // ReceiptStatusError constructor: { transactionReceipt, status, transactionId }
+  return new ReceiptStatusError({
+    transactionReceipt: {} as any,
+    status: statusValue,
+    transactionId: txId,
+  });
+}
+
+describe('BaseTransactionTool.handleError()', () => {
+  const tool = new StubTransactionTool();
+  const ctx: Context = {};
+
+  describe('ReceiptStatusError — structured fields preserved', () => {
+    it('sets status ERROR and errorCode to the SDK status name', async () => {
+      const err = makeReceiptStatusError(Status.InsufficientPayerBalance);
+      const result = await tool.handleError(err, ctx);
+
+      expect(result.raw.status).toBe('ERROR');
+      expect(result.raw.errorCode).toBe('INSUFFICIENT_PAYER_BALANCE');
+    });
+
+    it('sets raw.transactionId to the transaction ID string', async () => {
+      const err = makeReceiptStatusError(Status.InvalidTransaction);
+      const result = await tool.handleError(err, ctx);
+
+      expect(typeof result.raw.transactionId).toBe('string');
+      expect(result.raw.transactionId).toMatch(/^0\.0\.\d+@/);
+    });
+
+    it('sets raw.error to the SDK message and humanMessage with tool name prefix', async () => {
+      const err = makeReceiptStatusError(Status.InvalidSignature);
+      const result = await tool.handleError(err, ctx);
+
+      expect(result.raw.error).toBe(err.message);
+      expect(result.raw.errorCode).toBe('INVALID_SIGNATURE');
+      expect(result.humanMessage).toBe(`Failed to execute ${tool.name}: ${err.message}`);
+    });
+
+    it('classifyToolResult maps it to kind failure with specific errorCode', async () => {
+      const { classifyToolResult } = await import('@/shared/utils/default-tool-output-parsing');
+      const err = makeReceiptStatusError(Status.InsufficientAccountBalance);
+      const envelope = await tool.handleError(err, ctx);
+      const classified = classifyToolResult(envelope);
+
+      expect(classified.kind).toBe('failure');
+      if (classified.kind === 'failure') {
+        expect(classified.errorCode).toBe('INSUFFICIENT_ACCOUNT_BALANCE');
+      }
+    });
+  });
+
+  describe('generic Error — falls through to BaseTool.handleError()', () => {
+    it('sets status ERROR with generic error message', async () => {
+      const err = new Error('network timeout');
+      const result = await tool.handleError(err, ctx);
+
+      expect(result.raw.status).toBe('ERROR');
+      expect(result.raw.error).toContain('network timeout');
+      expect(result.raw.errorCode).toBeUndefined();
+      expect(result.raw.transactionId).toBeUndefined();
+    });
+
+    it('classifyToolResult maps it to kind failure with errorCode ERROR', async () => {
+      const { classifyToolResult } = await import('@/shared/utils/default-tool-output-parsing');
+      const envelope = await tool.handleError(new Error('oops'), ctx);
+      const classified = classifyToolResult(envelope);
+
+      expect(classified.kind).toBe('failure');
+      if (classified.kind === 'failure') {
+        expect(classified.errorCode).toBe('ERROR');
+      }
+    });
+  });
+});

--- a/packages/core/tests/unit/tools/create-account.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-account.unit.test.ts
@@ -108,10 +108,10 @@ describe('create-account tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, params);
     expect(res).toBeDefined();
-    expect(res.humanMessage).toContain('Failed to create account');
+    expect(res.humanMessage).toContain('Failed to execute Create Account');
     expect(res.humanMessage).toContain('boom');
     expect(res.raw).toBeDefined();
-    expect(res.raw.error).toContain('Failed to create account');
+    expect(res.raw.error).toContain('Failed to execute Create Account');
   });
 
   it('returns generic failure response object when a non-Error is thrown', async () => {
@@ -125,7 +125,7 @@ describe('create-account tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, params);
     expect(res).toBeDefined();
-    expect(res.humanMessage).toContain('Failed to create account');
-    expect(res.raw.error).toContain('Failed to create account');
+    expect(res.humanMessage).toContain('Failed to execute Create Account');
+    expect(res.raw.error).toContain('Failed to execute Create Account');
   });
 });

--- a/packages/core/tests/unit/tools/create-erc20.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-erc20.unit.test.ts
@@ -138,8 +138,8 @@ describe('createERC20 tool (unit)', () => {
 
     const res = await tool.execute(client, context, params);
 
-    expect(res.humanMessage).toContain('Failed to create ERC20 token: boom');
-    expect(res.raw.error).toContain('Failed to create ERC20 token: boom');
+    expect(res.humanMessage).toContain('Failed to execute Create ERC20 Token: boom');
+    expect(res.raw.error).toContain('Failed to execute Create ERC20 Token: boom');
     expect(res.raw.status).toBe('ERROR');
   });
 
@@ -153,8 +153,8 @@ describe('createERC20 tool (unit)', () => {
 
     const res = await tool.execute(client, context, params);
 
-    expect(res.humanMessage).toBe('Failed to create ERC20 token');
-    expect(res.raw.error).toBe('Failed to create ERC20 token');
+    expect(res.humanMessage).toBe('Failed to execute Create ERC20 Token');
+    expect(res.raw.error).toBe('Failed to execute Create ERC20 Token');
     expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/create-erc20.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-erc20.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi, Mock } from 'vitest';
-import { AccountId, Client, PrivateKey, Status } from '@hiero-ledger/sdk';
+import { AccountId, Client, PrivateKey} from '@hiero-ledger/sdk';
 import toolFactory, { CREATE_ERC20_TOOL } from '@/plugins/core-evm-plugin/tools/erc20/create-erc20';
 import { createERC20Parameters } from '@/shared/parameter-schemas/evm.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -140,7 +140,7 @@ describe('createERC20 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('Failed to create ERC20 token: boom');
     expect(res.raw.error).toContain('Failed to create ERC20 token: boom');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns generic failure message when a non-Error is thrown', async () => {
@@ -155,6 +155,6 @@ describe('createERC20 tool (unit)', () => {
 
     expect(res.humanMessage).toBe('Failed to create ERC20 token');
     expect(res.raw.error).toBe('Failed to create ERC20 token');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/create-erc721.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-erc721.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi, Mock } from 'vitest';
-import { AccountId, Client, PrivateKey, Status } from '@hiero-ledger/sdk';
+import { AccountId, Client, PrivateKey} from '@hiero-ledger/sdk';
 import toolFactory, { CREATE_ERC721_TOOL } from '@/plugins/core-evm-plugin/tools/erc721/create-erc721';
 import { createERC721Parameters } from '@/shared/parameter-schemas/evm.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -153,7 +153,7 @@ describe('createERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('boom');
     expect(res.raw.error).toContain('boom');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns generic failure message when a non-Error is thrown', async () => {
@@ -168,6 +168,6 @@ describe('createERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('Failed to create ERC721 token');
     expect(res.raw.error).toContain('Failed to create ERC721 token');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/create-erc721.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-erc721.unit.test.ts
@@ -166,8 +166,8 @@ describe('createERC721 tool (unit)', () => {
 
     const res = await tool.execute(client, context, params);
 
-    expect(res.humanMessage).toContain('Failed to create ERC721 token');
-    expect(res.raw.error).toContain('Failed to create ERC721 token');
+    expect(res.humanMessage).toContain('Failed to execute Create ERC721 Token');
+    expect(res.raw.error).toContain('Failed to execute Create ERC721 Token');
     expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/create-fungible-token-tool.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-fungible-token-tool.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client, Status, TokenSupplyType } from '@hiero-ledger/sdk';
+import { Client, TokenSupplyType } from '@hiero-ledger/sdk';
 import toolFactory, { CREATE_FUNGIBLE_TOKEN_TOOL } from '@/plugins/core-token-plugin/tools/fungible-token/create-fungible-token';
 import z from 'zod';
 import {
@@ -145,7 +145,7 @@ describe('create-token tool (unit)', () => {
     expect(res.humanMessage).toContain('boom');
     expect(res.raw.error).toContain('Failed to create fungible token');
     expect(res.raw.error).toContain('boom');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns aligned generic failure response when a non-Error is thrown', async () => {
@@ -159,6 +159,6 @@ describe('create-token tool (unit)', () => {
     const res = await tool.execute(client, context, params);
     expect(res.humanMessage).toBe('Failed to create fungible token');
     expect(res.raw.error).toBe('Failed to create fungible token');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/create-fungible-token-tool.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-fungible-token-tool.unit.test.ts
@@ -141,9 +141,9 @@ describe('create-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to create fungible token');
+    expect(res.humanMessage).toContain('Failed to execute Create Fungible Token');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to create fungible token');
+    expect(res.raw.error).toContain('Failed to execute Create Fungible Token');
     expect(res.raw.error).toContain('boom');
     expect(res.raw.status).toBe('ERROR');
   });
@@ -157,8 +157,8 @@ describe('create-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toBe('Failed to create fungible token');
-    expect(res.raw.error).toBe('Failed to create fungible token');
+    expect(res.humanMessage).toBe('Failed to execute Create Fungible Token');
+    expect(res.raw.error).toBe('Failed to execute Create Fungible Token');
     expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/create-non-fungible-token-tool.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-non-fungible-token-tool.unit.test.ts
@@ -138,9 +138,9 @@ describe('create-non-fungible-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to create non-fungible token');
+    expect(res.humanMessage).toContain('Failed to execute Create Non-Fungible Token');
     expect(res.humanMessage).toContain('NFT creation failed');
-    expect(res.raw.error).toContain('Failed to create non-fungible token');
+    expect(res.raw.error).toContain('Failed to execute Create Non-Fungible Token');
     expect(res.raw.error).toContain('NFT creation failed');
   });
 
@@ -153,7 +153,7 @@ describe('create-non-fungible-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toBe('Failed to create non-fungible token');
-    expect(res.raw.error).toBe('Failed to create non-fungible token');
+    expect(res.humanMessage).toBe('Failed to execute Create Non-Fungible Token');
+    expect(res.raw.error).toBe('Failed to execute Create Non-Fungible Token');
   });
 });

--- a/packages/core/tests/unit/tools/create-topic.unit.test.ts
+++ b/packages/core/tests/unit/tools/create-topic.unit.test.ts
@@ -101,9 +101,9 @@ describe('CreateTopicTool', () => {
     });
 
     const res: any = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to create topic');
+    expect(res.humanMessage).toContain('Failed to execute Create Topic');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to create topic');
+    expect(res.raw.error).toContain('Failed to execute Create Topic');
   });
 
   it('returns generic failure response object when a non-Error is thrown', async () => {
@@ -116,7 +116,7 @@ describe('CreateTopicTool', () => {
     });
 
     const res: any = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to create topic');
-    expect(res.raw.error).toContain('Failed to create topic');
+    expect(res.humanMessage).toContain('Failed to execute Create Topic');
+    expect(res.raw.error).toContain('Failed to execute Create Topic');
   });
 });

--- a/packages/core/tests/unit/tools/delete-account.unit.test.ts
+++ b/packages/core/tests/unit/tools/delete-account.unit.test.ts
@@ -92,9 +92,9 @@ describe('delete-account tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, params as any);
     expect(res).toBeDefined();
-    expect(res.humanMessage).toContain('Failed to delete account');
+    expect(res.humanMessage).toContain('Failed to execute Delete Account');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to delete account');
+    expect(res.raw.error).toContain('Failed to execute Delete Account');
   });
 
   it('returns generic failure response object when a non-Error is thrown', async () => {
@@ -108,7 +108,7 @@ describe('delete-account tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, params as any);
     expect(res).toBeDefined();
-    expect(res.humanMessage).toContain('Failed to delete account');
-    expect(res.raw.error).toContain('Failed to delete account');
+    expect(res.humanMessage).toContain('Failed to execute Delete Account');
+    expect(res.raw.error).toContain('Failed to execute Delete Account');
   });
 });

--- a/packages/core/tests/unit/tools/delete-hbar-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/delete-hbar-allowance.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client} from '@hiero-ledger/sdk';
 import toolFactory, {
   DELETE_HBAR_ALLOWANCE_TOOL,
 } from '@/plugins/core-account-plugin/tools/account/delete-hbar-allowance';
@@ -108,7 +108,7 @@ describe('delete-hbar-allowance tool (unit)', () => {
     const res: any = await tool.execute(client, context, params as any);
 
     expect(res).toBeDefined();
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
     expect(res.humanMessage).toContain('Failed to delete hbar allowance');
     expect(res.humanMessage).toContain('Test normaliser failure');
   });

--- a/packages/core/tests/unit/tools/delete-hbar-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/delete-hbar-allowance.unit.test.ts
@@ -109,7 +109,7 @@ describe('delete-hbar-allowance tool (unit)', () => {
 
     expect(res).toBeDefined();
     expect(res.raw.status).toBe('ERROR');
-    expect(res.humanMessage).toContain('Failed to delete hbar allowance');
+    expect(res.humanMessage).toContain('Failed to execute Delete HBAR Allowance');
     expect(res.humanMessage).toContain('Test normaliser failure');
   });
 });

--- a/packages/core/tests/unit/tools/delete-non-fungible-token-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/delete-non-fungible-token-allowance.unit.test.ts
@@ -105,7 +105,7 @@ describe('delete-nft-allowance tool (unit)', () => {
     const res: any = await tool.execute(client, context, params as any);
 
     expect(res).toBeDefined();
-    expect(res.humanMessage).toContain('Failed to delete NFT allowance');
+    expect(res.humanMessage).toContain('Failed to execute Delete Non Fungible Token Allowance');
     expect(res.humanMessage).toContain('Normalisation error');
   });
 });

--- a/packages/core/tests/unit/tools/delete-token-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/delete-token-allowance.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client} from '@hiero-ledger/sdk';
 import toolFactory, { DELETE_TOKEN_ALLOWANCE_TOOL } from '@/plugins/core-token-plugin/tools/fungible-token/delete-token-allowance';
 
 // ---- Mocks ----
@@ -124,7 +124,7 @@ describe('delete-token-allowance tool (unit)', () => {
     const res: any = await tool.execute(client, context, params as any);
 
     expect(res).toBeDefined();
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
     expect(res.humanMessage).toContain('Failed to delete token allowance');
     expect(res.humanMessage).toContain('Test normaliser failure');
   });

--- a/packages/core/tests/unit/tools/delete-token-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/delete-token-allowance.unit.test.ts
@@ -125,7 +125,7 @@ describe('delete-token-allowance tool (unit)', () => {
 
     expect(res).toBeDefined();
     expect(res.raw.status).toBe('ERROR');
-    expect(res.humanMessage).toContain('Failed to delete token allowance');
+    expect(res.humanMessage).toContain('Failed to execute Delete Token Allowance');
     expect(res.humanMessage).toContain('Test normaliser failure');
   });
 });

--- a/packages/core/tests/unit/tools/delete-topic.unit.test.ts
+++ b/packages/core/tests/unit/tools/delete-topic.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client} from '@hiero-ledger/sdk';
 import toolFactory, {
   DELETE_TOPIC_TOOL,
   DeleteTopicTool,
@@ -94,7 +94,7 @@ describe('DeleteTopicTool', () => {
     expect(res.humanMessage).toContain('Failed to delete the topic');
     expect(res.humanMessage).toContain('boom');
     expect(res.raw.error).toContain('Failed to delete the topic');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns generic failure response object when a non-Error is thrown', async () => {
@@ -109,6 +109,6 @@ describe('DeleteTopicTool', () => {
     const res: any = await tool.execute(client, context, params);
     expect(res.humanMessage).toContain('Failed to delete the topic');
     expect(res.raw.error).toContain('Failed to delete the topic');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/delete-topic.unit.test.ts
+++ b/packages/core/tests/unit/tools/delete-topic.unit.test.ts
@@ -91,9 +91,9 @@ describe('DeleteTopicTool', () => {
     });
 
     const res: any = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to delete the topic');
+    expect(res.humanMessage).toContain('Failed to execute Delete Topic');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to delete the topic');
+    expect(res.raw.error).toContain('Failed to execute Delete Topic');
     expect(res.raw.status).toBe('ERROR');
   });
 
@@ -107,8 +107,8 @@ describe('DeleteTopicTool', () => {
     });
 
     const res: any = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to delete the topic');
-    expect(res.raw.error).toContain('Failed to delete the topic');
+    expect(res.humanMessage).toContain('Failed to execute Delete Topic');
+    expect(res.raw.error).toContain('Failed to execute Delete Topic');
     expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/dissociate-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/dissociate-token.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { Client, AccountId, TokenId, Status } from '@hiero-ledger/sdk';
+import { Client, AccountId, TokenId} from '@hiero-ledger/sdk';
 import tool from '@/plugins/core-token-plugin/tools/dissociate-token';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
 import HederaBuilder from '@/shared/hedera-utils/hedera-builder';
@@ -77,7 +77,7 @@ describe('Dissociate Token Tool', () => {
     const result = await toolInstance.execute(client, context, params);
 
     expect(result.humanMessage).toContain('Failed to dissociate token');
-    expect(result.raw.status).toBe(Status.InvalidTransaction);
+    expect(result.raw.status).toBe('ERROR');
     expect(result.raw.error).toContain('Test error');
   });
 
@@ -86,7 +86,7 @@ describe('Dissociate Token Tool', () => {
     const params: any = { tokenIds: [] }; // invalid
 
     await expect(toolInstance.execute(client, context, params)).resolves.toMatchObject({
-      raw: { status: Status.InvalidTransaction },
+      raw: { status: 'ERROR' },
       humanMessage: expect.stringContaining('Failed to dissociate token'),
     });
   });

--- a/packages/core/tests/unit/tools/dissociate-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/dissociate-token.unit.test.ts
@@ -76,7 +76,7 @@ describe('Dissociate Token Tool', () => {
     const toolInstance = tool(context);
     const result = await toolInstance.execute(client, context, params);
 
-    expect(result.humanMessage).toContain('Failed to dissociate token');
+    expect(result.humanMessage).toContain('Failed to execute Dissociate Token');
     expect(result.raw.status).toBe('ERROR');
     expect(result.raw.error).toContain('Test error');
   });
@@ -87,7 +87,7 @@ describe('Dissociate Token Tool', () => {
 
     await expect(toolInstance.execute(client, context, params)).resolves.toMatchObject({
       raw: { status: 'ERROR' },
-      humanMessage: expect.stringContaining('Failed to dissociate token'),
+      humanMessage: expect.stringContaining('Failed to execute Dissociate Token'),
     });
   });
 

--- a/packages/core/tests/unit/tools/get-account-query.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-account-query.unit.test.ts
@@ -87,7 +87,7 @@ describe('get-account-query tool (unit)', () => {
     });
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to get account query');
+    expect(res.humanMessage).toContain('Failed to execute Get Account Query');
     expect(res.humanMessage).toContain('boom');
   });
 
@@ -103,6 +103,6 @@ describe('get-account-query tool (unit)', () => {
     });
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toBe('Failed to get account query');
+    expect(res.humanMessage).toBe('Failed to execute Get Account Query');
   });
 });

--- a/packages/core/tests/unit/tools/get-account-query.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-account-query.unit.test.ts
@@ -65,7 +65,7 @@ describe('get-account-query tool (unit)', () => {
       hbarBalance: toHbar(new BigNumber(fakeAccount.balance.balance)).toString()
     };
 
-    expect(res.raw).toEqual({ accountId: params.accountId, account: expectedAccountRaw });
+    expect(res.raw).toEqual({ accountId: params.accountId, account: expectedAccountRaw, status: 'SUCCESS' });
     expect(res.humanMessage).toContain(`Details for ${fakeAccount.accountId}`);
     expect(res.humanMessage).toContain(
       `Balance: ${toHbar(new BigNumber(fakeAccount.balance.balance)).toString()} HBAR`,

--- a/packages/core/tests/unit/tools/get-account-token-balances.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-account-token-balances.unit.test.ts
@@ -108,7 +108,7 @@ describe('GetAccountTokenBalancesQueryTool', () => {
     });
     const tool = new GetAccountTokenBalancesQueryTool(context);
     const result = await tool.execute(client, context, { accountId: '0.0.1' });
-    expect(result.humanMessage).toBe('Failed to get account token balances');
-    expect(result.raw.error).toContain('Failed to get account token balances');
+    expect(result.humanMessage).toBe('Failed to execute Get Account Token Balances');
+    expect(result.raw.error).toContain('Failed to execute Get Account Token Balances');
   });
 });

--- a/packages/core/tests/unit/tools/get-contract-info-query.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-contract-info-query.unit.test.ts
@@ -91,7 +91,7 @@ describe('get-contract-info tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, { contractId: '0.0.8888' });
 
-    expect(res.humanMessage).toContain('Failed to get contract info');
-    expect(res.raw.error).toContain('Failed to get contract info');
+    expect(res.humanMessage).toContain('Failed to execute Get Contract Info');
+    expect(res.raw.error).toContain('Failed to execute Get Contract Info');
   });
 });

--- a/packages/core/tests/unit/tools/get-contract-info-query.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-contract-info-query.unit.test.ts
@@ -65,7 +65,7 @@ describe('get-contract-info tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, { contractId: '0.0.5005' });
 
-    expect(res.raw).toEqual({ contractId: '0.0.5005', contractInfo });
+    expect(res.raw).toEqual({ contractId: '0.0.5005', contractInfo, status: 'SUCCESS' });
     expect(res.humanMessage).toContain('Here are the details for contract **0.0.5005**:');
     expect(res.humanMessage).toContain('Memo');
     expect(mockGetContractInfo).toHaveBeenCalledWith('0.0.5005');

--- a/packages/core/tests/unit/tools/get-exchange-rate.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-exchange-rate.unit.test.ts
@@ -83,8 +83,8 @@ describe('get-exchange-rate tool (unit)', () => {
     });
 
     const res: any = await tool.execute(client, context, { timestamp: 'x' } as any);
-    expect(res.humanMessage).toBe('boom');
-    expect(res.raw.error).toBe('boom');
+    expect(res.humanMessage).toBe('Failed to execute Get Exchange Rate: boom');
+    expect(res.raw.error).toBe('Failed to execute Get Exchange Rate: boom');
   });
 
   it('returns generic message when non-Error thrown', async () => {
@@ -101,7 +101,7 @@ describe('get-exchange-rate tool (unit)', () => {
     });
 
     const res: any = await tool.execute(client, context, {} as any);
-    expect(res.humanMessage).toBe('Failed to get exchange rate');
-    expect(res.raw.error).toBe('Failed to get exchange rate');
+    expect(res.humanMessage).toBe('Failed to execute Get Exchange Rate');
+    expect(res.raw.error).toBe('Failed to execute Get Exchange Rate');
   });
 });

--- a/packages/core/tests/unit/tools/get-hbar-balance.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-hbar-balance.unit.test.ts
@@ -48,7 +48,7 @@ describe('get-hbar-balance tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, { accountId: '0.0.1001' } as any);
 
-    expect(res.raw).toEqual({ accountId: '0.0.1001', hbarBalance: '123.456789' });
+    expect(res.raw).toEqual({ accountId: '0.0.1001', hbarBalance: '123.456789', status: 'SUCCESS' });
     expect(res.humanMessage).toContain('Account 0.0.1001 has a balance of 123.456789 HBAR');
 
     const { default: HederaParameterNormaliser } = await import(

--- a/packages/core/tests/unit/tools/get-hbar-balance.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-hbar-balance.unit.test.ts
@@ -71,7 +71,7 @@ describe('get-hbar-balance tool (unit)', () => {
     });
 
     const res: any = await tool.execute(client, context, { accountId: '0.0.x' } as any);
-    expect(res.humanMessage).toContain('Failed to get HBAR balance');
+    expect(res.humanMessage).toContain('Failed to execute Get HBAR Balance');
     expect(res.humanMessage).toContain('boom');
   });
 
@@ -89,6 +89,6 @@ describe('get-hbar-balance tool (unit)', () => {
     });
 
     const res: any = await tool.execute(client, context, { accountId: '0.0.x' } as any);
-    expect(res.humanMessage).toBe('Failed to get HBAR balance');
+    expect(res.humanMessage).toBe('Failed to execute Get HBAR Balance');
   });
 });

--- a/packages/core/tests/unit/tools/get-pending-airdrop-query.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-pending-airdrop-query.unit.test.ts
@@ -148,7 +148,7 @@ describe('get-pending-airdrop-query tool (unit)', () => {
     });
 
     const res: any = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to get pending airdrops');
-    expect(res.raw.error).toContain('Failed to get pending airdrops');
+    expect(res.humanMessage).toContain('Failed to execute Get Pending Airdrops');
+    expect(res.raw.error).toContain('Failed to execute Get Pending Airdrops');
   });
 });

--- a/packages/core/tests/unit/tools/get-token-info-query.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-token-info-query.unit.test.ts
@@ -74,6 +74,7 @@ describe('get-token-info-query tool (unit)', () => {
     expect(res.raw).toEqual({
       tokenId: params.tokenId,
       tokenInfo: { ...fakeToken, token_id: params.tokenId },
+      status: 'SUCCESS',
     });
     expect(res.humanMessage).toContain(`${params.tokenId}`);
     expect(res.humanMessage).toContain(`Token Name**: ${fakeToken.name}`);

--- a/packages/core/tests/unit/tools/get-token-info-query.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-token-info-query.unit.test.ts
@@ -101,9 +101,9 @@ describe('get-token-info-query tool (unit)', () => {
     });
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to get token info');
+    expect(res.humanMessage).toContain('Failed to execute Get Token Info');
     expect(res.humanMessage).toContain('token not found');
-    expect(res.raw.error).toContain('Failed to get token info');
+    expect(res.raw.error).toContain('Failed to execute Get Token Info');
     expect(res.raw.error).toContain('token not found');
   });
 
@@ -119,8 +119,8 @@ describe('get-token-info-query tool (unit)', () => {
     });
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to get token info');
-    expect(res.raw.error).toContain('Failed to get token info');
+    expect(res.humanMessage).toContain('Failed to execute Get Token Info');
+    expect(res.raw.error).toContain('Failed to execute Get Token Info');
   });
 
   it('handles infinite supply tokens correctly', async () => {

--- a/packages/core/tests/unit/tools/get-topic-info.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-topic-info.unit.test.ts
@@ -94,7 +94,7 @@ describe('Get Topic Info Tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, params);
 
-    expect(res.humanMessage).toBe('Failed to get topic info');
-    expect(res.raw.error).toBe('Failed to get topic info');
+    expect(res.humanMessage).toBe('Failed to execute Get Topic Info');
+    expect(res.raw.error).toBe('Failed to execute Get Topic Info');
   });
 });

--- a/packages/core/tests/unit/tools/get-topic-messages.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-topic-messages.unit.test.ts
@@ -105,7 +105,7 @@ describe('Get Topic Messages Tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, params);
 
-    expect(res.humanMessage).toBe('Failed to get topic messages');
-    expect(res.raw.error).toBe('Failed to get topic messages');
+    expect(res.humanMessage).toBe('Failed to execute Get Topic Messages');
+    expect(res.raw.error).toBe('Failed to execute Get Topic Messages');
   });
 });

--- a/packages/core/tests/unit/tools/get-transaction-record.unit.test.ts
+++ b/packages/core/tests/unit/tools/get-transaction-record.unit.test.ts
@@ -147,7 +147,7 @@ describe('Tool Logic - getTransactionRecordQuery', () => {
     const tool = toolFactory(context);
     (mockService.getTransactionRecord as any).mockRejectedValue(new Error('boom'));
     const result = await tool.execute(client, context, { transactionId: '0.0.1-1-1' });
-    expect(result.humanMessage).toContain('Failed to get transaction record');
+    expect(result.humanMessage).toContain('Failed to execute Get Transaction Record Query');
     expect(result.humanMessage).toContain('boom');
   });
 
@@ -157,6 +157,6 @@ describe('Tool Logic - getTransactionRecordQuery', () => {
       throw 'string error';
     });
     const result = await tool.execute(client, context, { transactionId: '0.0.1-1-1' });
-    expect(result.humanMessage).toBe('Failed to get transaction record');
+    expect(result.humanMessage).toBe('Failed to execute Get Transaction Record Query');
   });
 });

--- a/packages/core/tests/unit/tools/mint-erc721.unit.test.ts
+++ b/packages/core/tests/unit/tools/mint-erc721.unit.test.ts
@@ -146,8 +146,8 @@ describe('mintERC721 tool (unit)', () => {
 
     const res = await tool.execute(client, context, params);
 
-    expect(res.humanMessage).toBe('Failed to mint ERC721');
-    expect(res.raw.error).toBe('Failed to mint ERC721');
+    expect(res.humanMessage).toBe('Failed to execute Mint ERC721');
+    expect(res.raw.error).toBe('Failed to execute Mint ERC721');
     expect(res.raw.status).toBe('ERROR');
   });
 

--- a/packages/core/tests/unit/tools/mint-erc721.unit.test.ts
+++ b/packages/core/tests/unit/tools/mint-erc721.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AccountId, Client, PrivateKey, Status } from '@hiero-ledger/sdk';
+import { AccountId, Client, PrivateKey} from '@hiero-ledger/sdk';
 import toolFactory, { MINT_ERC721_TOOL } from '@/plugins/core-evm-plugin/tools/erc721/mint-erc721';
 import { mintERC721Parameters } from '@/shared/parameter-schemas/evm.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -133,7 +133,7 @@ describe('mintERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('mint failed');
     expect(res.raw.error).toContain('mint failed');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns generic failure message when a non-Error is thrown', async () => {
@@ -148,7 +148,7 @@ describe('mintERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toBe('Failed to mint ERC721');
     expect(res.raw.error).toBe('Failed to mint ERC721');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('handles parameter validation errors', async () => {
@@ -163,7 +163,7 @@ describe('mintERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('Invalid parameters: Field "toAddress" - Invalid address');
     expect(res.raw.error).toContain('Invalid parameters: Field "toAddress" - Invalid address');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('handles address resolution errors', async () => {
@@ -178,6 +178,6 @@ describe('mintERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('Account not found: 0.0.9999');
     expect(res.raw.error).toContain('Account not found: 0.0.9999');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/mint-fungible-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/mint-fungible-token.unit.test.ts
@@ -112,9 +112,9 @@ describe('mint-fungible-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to mint fungible token');
+    expect(res.humanMessage).toContain('Failed to execute Mint Fungible Token');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to mint fungible token');
+    expect(res.raw.error).toContain('Failed to execute Mint Fungible Token');
     expect(res.raw.error).toContain('boom');
     expect(res.raw.status).toBe('ERROR');
   });
@@ -128,7 +128,7 @@ describe('mint-fungible-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toBe('Failed to mint fungible token');
-    expect(res.raw.error).toBe('Failed to mint fungible token');
+    expect(res.humanMessage).toBe('Failed to execute Mint Fungible Token');
+    expect(res.raw.error).toBe('Failed to execute Mint Fungible Token');
   });
 });

--- a/packages/core/tests/unit/tools/mint-fungible-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/mint-fungible-token.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client} from '@hiero-ledger/sdk';
 import toolFactory, { MINT_FUNGIBLE_TOKEN_TOOL } from '@/plugins/core-token-plugin/tools/fungible-token/mint-fungible-token';
 import z from 'zod';
 import { mintFungibleTokenParameters } from '@/shared/parameter-schemas/token.zod';
@@ -116,7 +116,7 @@ describe('mint-fungible-token tool (unit)', () => {
     expect(res.humanMessage).toContain('boom');
     expect(res.raw.error).toContain('Failed to mint fungible token');
     expect(res.raw.error).toContain('boom');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns aligned generic failure response when a non-Error is thrown', async () => {

--- a/packages/core/tests/unit/tools/mint-non-fungible-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/mint-non-fungible-token.unit.test.ts
@@ -111,9 +111,9 @@ describe('mint-non-fungible-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to mint non-fungible token');
+    expect(res.humanMessage).toContain('Failed to execute Mint Non-Fungible Token');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to mint non-fungible token');
+    expect(res.raw.error).toContain('Failed to execute Mint Non-Fungible Token');
     expect(res.raw.error).toContain('boom');
   });
 
@@ -126,7 +126,7 @@ describe('mint-non-fungible-token tool (unit)', () => {
     const client = makeClient();
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toBe('Failed to mint non-fungible token');
-    expect(res.raw.error).toBe('Failed to mint non-fungible token');
+    expect(res.humanMessage).toBe('Failed to execute Mint Non-Fungible Token');
+    expect(res.raw.error).toBe('Failed to execute Mint Non-Fungible Token');
   });
 });

--- a/packages/core/tests/unit/tools/schedule-delete.unit.test.ts
+++ b/packages/core/tests/unit/tools/schedule-delete.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client} from '@hiero-ledger/sdk';
 import toolFactory, {
   SCHEDULE_DELETE_TOOL,
 } from '@/plugins/core-account-plugin/tools/account/schedule-delete';
@@ -153,7 +153,7 @@ describe('schedule-delete tool (unit)', () => {
       scheduleId: '0.0.999999',
     } as any);
 
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
     expect(res.humanMessage).toContain('Failed to delete scheduled transaction');
   });
 });

--- a/packages/core/tests/unit/tools/schedule-delete.unit.test.ts
+++ b/packages/core/tests/unit/tools/schedule-delete.unit.test.ts
@@ -81,7 +81,7 @@ describe('schedule-delete tool (unit)', () => {
     const res = await tool.execute(client, context, {
       scheduleId: '0.0.999999',
     } as any);
-    expect(res.humanMessage).toBe('Failed to delete scheduled transaction: Invalid schedule ID');
+    expect(res.humanMessage).toBe('Failed to execute Delete Scheduled Transaction: Invalid schedule ID');
   });
 
   it('returns generic failure message when a non-Error is thrown', async () => {
@@ -96,7 +96,7 @@ describe('schedule-delete tool (unit)', () => {
     const res = await tool.execute(client, context, {
       scheduleId: '0.0.123456',
     } as any);
-    expect(res.humanMessage).toBe('Failed to delete scheduled transaction');
+    expect(res.humanMessage).toBe('Failed to execute Delete Scheduled Transaction');
   });
 
   it('handles different schedule ID formats', async () => {
@@ -135,7 +135,7 @@ describe('schedule-delete tool (unit)', () => {
     } as any);
     expect(consoleSpy).toHaveBeenCalledWith(
       '[schedule_delete_tool]',
-      'Failed to delete scheduled transaction: Test error',
+      'Failed to execute Delete Scheduled Transaction: Test error',
     );
     consoleSpy.mockRestore();
   });
@@ -154,6 +154,6 @@ describe('schedule-delete tool (unit)', () => {
     } as any);
 
     expect(res.raw.status).toBe('ERROR');
-    expect(res.humanMessage).toContain('Failed to delete scheduled transaction');
+    expect(res.humanMessage).toContain('Failed to execute Delete Scheduled Transaction');
   });
 });

--- a/packages/core/tests/unit/tools/sign-schedule-transaction.unit.test.ts
+++ b/packages/core/tests/unit/tools/sign-schedule-transaction.unit.test.ts
@@ -82,7 +82,7 @@ describe('sign-schedule-transaction tool (unit)', () => {
     const res = await tool.execute(client, context, {
       scheduleId: '0.0.999999',
     } as any);
-    expect(res.humanMessage).toBe('Failed to sign scheduled transaction: Invalid schedule ID');
+    expect(res.humanMessage).toBe('Failed to execute Sign Scheduled Transaction: Invalid schedule ID');
   });
 
   it('returns generic failure message when a non-Error is thrown', async () => {
@@ -97,7 +97,7 @@ describe('sign-schedule-transaction tool (unit)', () => {
     const res = await tool.execute(client, context, {
       scheduleId: '0.0.123456',
     } as any);
-    expect(res.humanMessage).toBe('Failed to sign scheduled transaction');
+    expect(res.humanMessage).toBe('Failed to execute Sign Scheduled Transaction');
   });
 
   it('handles different schedule ID formats', async () => {
@@ -137,7 +137,7 @@ describe('sign-schedule-transaction tool (unit)', () => {
     } as any);
     expect(consoleSpy).toHaveBeenCalledWith(
       '[sign_schedule_transaction_tool]',
-      'Failed to sign scheduled transaction: Test error',
+      'Failed to execute Sign Scheduled Transaction: Test error',
     );
     consoleSpy.mockRestore();
   });
@@ -156,6 +156,6 @@ describe('sign-schedule-transaction tool (unit)', () => {
     } as any);
 
     expect(res.raw.status).toBe('ERROR');
-    expect(res.humanMessage).toContain('Failed to sign scheduled transaction');
+    expect(res.humanMessage).toContain('Failed to execute Sign Scheduled Transaction');
   });
 });

--- a/packages/core/tests/unit/tools/sign-schedule-transaction.unit.test.ts
+++ b/packages/core/tests/unit/tools/sign-schedule-transaction.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client, Status } from '@hiero-ledger/sdk';
+import { Client} from '@hiero-ledger/sdk';
 import toolFactory, {
   SIGN_SCHEDULE_TRANSACTION_TOOL,
 } from '@/plugins/core-account-plugin/tools/account/sign-schedule-transaction';
@@ -155,7 +155,7 @@ describe('sign-schedule-transaction tool (unit)', () => {
       scheduleId: '0.0.999999',
     } as any);
 
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
     expect(res.humanMessage).toContain('Failed to sign scheduled transaction');
   });
 });

--- a/packages/core/tests/unit/tools/submit-topic-message.unit.test.ts
+++ b/packages/core/tests/unit/tools/submit-topic-message.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Client } from '@hiero-ledger/sdk';
+import { AccountId, Client, ReceiptStatusError, Status, TransactionId } from '@hiero-ledger/sdk';
 import toolFactory, {
   SUBMIT_TOPIC_MESSAGE_TOOL,
   SubmitTopicMessageTool,
@@ -84,10 +84,29 @@ describe('SubmitTopicMessageTool', () => {
     });
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toContain('Failed to submit message to topic');
+    expect(res.humanMessage).toContain('Failed to execute Submit Topic Message');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to submit message to topic');
+    expect(res.raw.error).toContain('Failed to execute Submit Topic Message');
     expect(res.raw.error).toContain('boom');
+  });
+
+  it('handleError with ReceiptStatusError sets errorCode and transactionId', async () => {
+    const txId = TransactionId.generate(new AccountId(0, 0, 1001));
+    const receiptError = new ReceiptStatusError({
+      transactionReceipt: {} as any,
+      status: Status.InsufficientPayerBalance,
+      transactionId: txId,
+    });
+
+    const tool = new SubmitTopicMessageTool(context);
+    const res = await tool.handleError(receiptError, context);
+
+    expect(res.raw.status).toBe('ERROR');
+    expect(res.raw.errorCode).toBe('INSUFFICIENT_PAYER_BALANCE');
+    expect(res.raw.transactionId).toMatch(/^0\.0\.\d+@/);
+    expect(res.raw.error).toBe(receiptError.message);
+    expect(res.humanMessage).toContain('Failed to execute Submit Topic Message');
+    expect(res.humanMessage).toContain('INSUFFICIENT_PAYER_BALANCE');
   });
 
   it('returns aligned generic failure response when a non-Error is thrown', async () => {
@@ -100,7 +119,7 @@ describe('SubmitTopicMessageTool', () => {
     });
 
     const res = await tool.execute(client, context, params);
-    expect(res.humanMessage).toBe('Failed to submit message to topic');
-    expect(res.raw.error).toBe('Failed to submit message to topic');
+    expect(res.humanMessage).toBe('Failed to execute Submit Topic Message');
+    expect(res.raw.error).toBe('Failed to execute Submit Topic Message');
   });
 });

--- a/packages/core/tests/unit/tools/transfer-erc20.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-erc20.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AccountId, Client, PrivateKey, Status } from '@hiero-ledger/sdk';
+import { AccountId, Client, PrivateKey} from '@hiero-ledger/sdk';
 import toolFactory, { TRANSFER_ERC20_TOOL } from '@/plugins/core-evm-plugin/tools/erc20/transfer-erc20';
 import { transferERC20Parameters } from '@/shared/parameter-schemas/evm.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -130,7 +130,7 @@ describe('transferERC20 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('insufficient balance');
     expect(res.raw.error).toContain('insufficient balance');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns generic failure message when a non-Error is thrown', async () => {
@@ -145,7 +145,7 @@ describe('transferERC20 tool (unit)', () => {
 
     expect(res.humanMessage).toBe('Failed to transfer ERC20');
     expect(res.raw.error).toBe('Failed to transfer ERC20');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('handles parameter validation errors', async () => {
@@ -162,7 +162,7 @@ describe('transferERC20 tool (unit)', () => {
       'Invalid parameters: Field "amount" must be greater than zero',
     );
     expect(res.raw.error).toContain('Invalid parameters: Field "amount" must be greater than zero');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('handles address resolution errors', async () => {
@@ -177,6 +177,6 @@ describe('transferERC20 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('Account not found: 0.0.9999');
     expect(res.raw.error).toContain('Account not found: 0.0.9999');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/transfer-erc20.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-erc20.unit.test.ts
@@ -143,8 +143,8 @@ describe('transferERC20 tool (unit)', () => {
 
     const res = await tool.execute(client, context, params);
 
-    expect(res.humanMessage).toBe('Failed to transfer ERC20');
-    expect(res.raw.error).toBe('Failed to transfer ERC20');
+    expect(res.humanMessage).toBe('Failed to execute Transfer ERC20');
+    expect(res.raw.error).toBe('Failed to execute Transfer ERC20');
     expect(res.raw.status).toBe('ERROR');
   });
 

--- a/packages/core/tests/unit/tools/transfer-erc721.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-erc721.unit.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AccountId, Client, PrivateKey, Status } from '@hiero-ledger/sdk';
+import { AccountId, Client, PrivateKey} from '@hiero-ledger/sdk';
 import toolFactory, { TRANSFER_ERC721_TOOL } from '@/plugins/core-evm-plugin/tools/erc721/transfer-erc721';
 import { transferERC721Parameters } from '@/shared/parameter-schemas/evm.zod';
 import HederaParameterNormaliser from '@/shared/hedera-utils/hedera-parameter-normaliser';
@@ -132,7 +132,7 @@ describe('transferERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('token not owned by sender');
     expect(res.raw.error).toContain('token not owned by sender');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('returns generic failure message when a non-Error is thrown', async () => {
@@ -147,7 +147,7 @@ describe('transferERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toBe('Failed to transfer ERC721');
     expect(res.raw.error).toBe('Failed to transfer ERC721');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('handles parameter validation errors', async () => {
@@ -166,7 +166,7 @@ describe('transferERC721 tool (unit)', () => {
     expect(res.raw.error).toContain(
       'Invalid parameters: Field "tokenId" - Number must be greater than or equal to 0',
     );
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('handles address resolution errors', async () => {
@@ -181,7 +181,7 @@ describe('transferERC721 tool (unit)', () => {
 
     expect(res.humanMessage).toContain('From account not found: 0.0.9999');
     expect(res.raw.error).toContain('From account not found: 0.0.9999');
-    expect(res.raw.status).toBe(Status.InvalidTransaction);
+    expect(res.raw.status).toBe('ERROR');
   });
 
   it('handles missing fromAddress by using context account', async () => {

--- a/packages/core/tests/unit/tools/transfer-erc721.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-erc721.unit.test.ts
@@ -145,8 +145,8 @@ describe('transferERC721 tool (unit)', () => {
 
     const res = await tool.execute(client, context, params);
 
-    expect(res.humanMessage).toBe('Failed to transfer ERC721');
-    expect(res.raw.error).toBe('Failed to transfer ERC721');
+    expect(res.humanMessage).toBe('Failed to execute Transfer ERC721');
+    expect(res.raw.error).toBe('Failed to execute Transfer ERC721');
     expect(res.raw.status).toBe('ERROR');
   });
 

--- a/packages/core/tests/unit/tools/transfer-fungible-token-with-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-fungible-token-with-allowance.unit.test.ts
@@ -96,7 +96,7 @@ describe('Transfer Fungible Token with Allowance Tool (unit)', () => {
 
     expect(result.humanMessage).toContain('Failed to transfer fungible token with allowance');
     expect(result.humanMessage).toContain('boom');
-    expect(result.raw.status).toBe(Status.InvalidTransaction);
+    expect(result.raw.status).toBe('ERROR');
   });
 
   it('should handle non-Error exceptions gracefully', async () => {
@@ -116,6 +116,6 @@ describe('Transfer Fungible Token with Allowance Tool (unit)', () => {
     const result = await tool.execute(client, context, params);
 
     expect(result.humanMessage).toBe('Failed to transfer fungible token with allowance');
-    expect(result.raw.status).toBe(Status.InvalidTransaction);
+    expect(result.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/transfer-fungible-token-with-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-fungible-token-with-allowance.unit.test.ts
@@ -94,7 +94,7 @@ describe('Transfer Fungible Token with Allowance Tool (unit)', () => {
     const tool = toolFactory(context);
     const result = await tool.execute(client, context, params);
 
-    expect(result.humanMessage).toContain('Failed to transfer fungible token with allowance');
+    expect(result.humanMessage).toContain('Failed to execute Transfer Fungible Token with Allowance');
     expect(result.humanMessage).toContain('boom');
     expect(result.raw.status).toBe('ERROR');
   });
@@ -115,7 +115,7 @@ describe('Transfer Fungible Token with Allowance Tool (unit)', () => {
     const tool = toolFactory(context);
     const result = await tool.execute(client, context, params);
 
-    expect(result.humanMessage).toBe('Failed to transfer fungible token with allowance');
+    expect(result.humanMessage).toBe('Failed to execute Transfer Fungible Token with Allowance');
     expect(result.raw.status).toBe('ERROR');
   });
 });

--- a/packages/core/tests/unit/tools/transfer-hbar-with-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-hbar-with-allowance.unit.test.ts
@@ -99,7 +99,7 @@ describe('transfer-hbar-with-allowance tool (unit)', () => {
       sourceAccountId: '0.0.1001',
     } as any);
 
-    expect(res.humanMessage).toContain('Failed to transfer HBAR');
+    expect(res.humanMessage).toContain('Failed to execute Transfer HBAR');
     expect(res.humanMessage).toContain('boom');
   });
 
@@ -117,6 +117,6 @@ describe('transfer-hbar-with-allowance tool (unit)', () => {
       sourceAccountId: '0.0.1001',
     } as any);
 
-    expect(res.humanMessage).toBe('Failed to transfer HBAR with allowance');
+    expect(res.humanMessage).toBe('Failed to execute Transfer HBAR with allowance');
   });
 });

--- a/packages/core/tests/unit/tools/transfer-hbar.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-hbar.unit.test.ts
@@ -98,7 +98,7 @@ describe('transfer-hbar tool (unit)', () => {
     const res = await tool.execute(client, context, {
       transfers: [{ accountId: '0.0.9', amount: 1 }],
     } as any);
-    expect(res.humanMessage).toContain('Failed to transfer HBAR');
+    expect(res.humanMessage).toContain('Failed to execute Transfer HBAR');
     expect(res.humanMessage).toContain('boom');
   });
 
@@ -114,6 +114,6 @@ describe('transfer-hbar tool (unit)', () => {
     const res = await tool.execute(client, context, {
       transfers: [{ accountId: '0.0.9', amount: 1 }],
     } as any);
-    expect(res.humanMessage).toBe('Failed to transfer HBAR');
+    expect(res.humanMessage).toBe('Failed to execute Transfer HBAR');
   });
 });

--- a/packages/core/tests/unit/tools/transfer-non-fungible-token-with-allowance.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-non-fungible-token-with-allowance.unit.test.ts
@@ -79,7 +79,7 @@ describe('transfer-nft-with-allowance tool', () => {
       tokenId: '0.0.2001',
       recipients: [{ recipientId: '0.0.3001', serialNumber: 1 }],
     });
-    expect(res.humanMessage).toContain('Failed to transfer non-fungible token with allowance:');
+    expect(res.humanMessage).toContain('Failed to execute Transfer Non Fungible Token with Allowance:');
     expect(res.humanMessage).toContain('boom');
   });
 });

--- a/packages/core/tests/unit/tools/transfer-non-fungible-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/transfer-non-fungible-token.unit.test.ts
@@ -128,7 +128,7 @@ describe('transfer-non-fungible-token tool', () => {
       tokenId: '0.0.2001',
       recipients: [{ recipientId: '0.0.3001', serialNumber: 1 }],
     });
-    expect(res.humanMessage).toContain('Failed to transfer non-fungible token:');
+    expect(res.humanMessage).toContain('Failed to execute Transfer Non Fungible Token:');
     expect(res.humanMessage).toContain('boom');
   });
 });

--- a/packages/core/tests/unit/tools/update-account.unit.test.ts
+++ b/packages/core/tests/unit/tools/update-account.unit.test.ts
@@ -95,9 +95,9 @@ describe('update-account tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, params as any);
     expect(res).toBeDefined();
-    expect(res.humanMessage).toContain('Failed to update account');
+    expect(res.humanMessage).toContain('Failed to execute Update Account');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to update account');
+    expect(res.raw.error).toContain('Failed to execute Update Account');
   });
 
   it('returns generic failure response object when a non-Error is thrown', async () => {
@@ -111,7 +111,7 @@ describe('update-account tool (unit)', () => {
 
     const res: any = await tool.execute(client, context, params as any);
     expect(res).toBeDefined();
-    expect(res.humanMessage).toContain('Failed to update account');
-    expect(res.raw.error).toContain('Failed to update account');
+    expect(res.humanMessage).toContain('Failed to execute Update Account');
+    expect(res.raw.error).toContain('Failed to execute Update Account');
   });
 });

--- a/packages/core/tests/unit/tools/update-token.unit.test.ts
+++ b/packages/core/tests/unit/tools/update-token.unit.test.ts
@@ -121,9 +121,9 @@ describe('update-token tool (unit)', () => {
     const client = makeClient();
 
     const res: any = await tool.execute(client, context, params as any);
-    expect(res.humanMessage).toContain('Failed to update token');
+    expect(res.humanMessage).toContain('Failed to execute Update Token');
     expect(res.humanMessage).toContain('boom');
-    expect(res.raw.error).toContain('Failed to update token');
+    expect(res.raw.error).toContain('Failed to execute Update Token');
   });
 
   it('returns generic failure response object when a non-Error is thrown', async () => {
@@ -135,8 +135,8 @@ describe('update-token tool (unit)', () => {
     const client = makeClient();
 
     const res: any = await tool.execute(client, context, params as any);
-    expect(res.humanMessage).toContain('Failed to update token');
-    expect(res.raw.error).toContain('Failed to update token');
+    expect(res.humanMessage).toContain('Failed to execute Update Token');
+    expect(res.raw.error).toContain('Failed to execute Update Token');
   });
 
   it('fails if the user public key does not match the token admin key', async () => {

--- a/packages/core/tests/unit/tools/update-topic.unit.test.ts
+++ b/packages/core/tests/unit/tools/update-topic.unit.test.ts
@@ -119,9 +119,9 @@ describe('UpdateTopicTool', () => {
     const client = makeClient();
 
     const res: any = await tool.execute(client, context, params as any);
-    expect(res.humanMessage).toContain('Failed to update topic');
+    expect(res.humanMessage).toContain('Failed to execute Update Topic');
     expect(res.humanMessage).toContain('kaboom');
-    expect(res.raw.error).toContain('Failed to update topic');
+    expect(res.raw.error).toContain('Failed to execute Update Topic');
   });
 
   it('returns generic failure response object when a non-Error is thrown', async () => {
@@ -133,8 +133,8 @@ describe('UpdateTopicTool', () => {
     const client = makeClient();
 
     const res: any = await tool.execute(client, context, params as any);
-    expect(res.humanMessage).toContain('Failed to update topic');
-    expect(res.raw.error).toContain('Failed to update topic');
+    expect(res.humanMessage).toContain('Failed to execute Update Topic');
+    expect(res.raw.error).toContain('Failed to execute Update Topic');
   });
 
   it('fails if the user public key does not match the topic admin key', async () => {

--- a/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
+++ b/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
@@ -71,7 +71,7 @@ describe('classifyToolResult', () => {
   });
 
   describe('failure', () => {
-    it('classifies ERROR status with error string', () => {
+    it('classifies ERROR status with error string — errorCode is ERROR', () => {
       const result = classifyToolResult({
         raw: { status: 'ERROR', error: 'Failed to get account: not found' },
         humanMessage: 'Failed to get account: not found',
@@ -81,6 +81,29 @@ describe('classifyToolResult', () => {
       if (result.kind === 'failure') {
         expect(result.errorCode).toBe('ERROR');
         expect(result.error).toBe('Failed to get account: not found');
+      }
+    });
+
+    it('uses raw.errorCode over raw.status when present — Hedera receipt failure shape', () => {
+      // This is the envelope produced by BaseTool.handleError() when a ReceiptStatusError
+      // is thrown: status stays 'ERROR' (discriminator) but errorCode carries the specific
+      // SDK status name so callers don't have to parse the prose message.
+      const result = classifyToolResult({
+        raw: {
+          status: 'ERROR',
+          errorCode: 'INSUFFICIENT_PAYER_BALANCE',
+          transactionId: '0.0.1@1700000000.000000001',
+          error:
+            'receipt for transaction 0.0.1@1700000000.000000001 contained error status INSUFFICIENT_PAYER_BALANCE',
+        },
+        humanMessage:
+          'receipt for transaction 0.0.1@1700000000.000000001 contained error status INSUFFICIENT_PAYER_BALANCE',
+      });
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.errorCode).toBe('INSUFFICIENT_PAYER_BALANCE');
+        expect(result.error).toContain('INSUFFICIENT_PAYER_BALANCE');
       }
     });
 
@@ -111,9 +134,9 @@ describe('classifyToolResult', () => {
     });
 
     it('classifies object status with error string as failure with UNKNOWN code', () => {
-      // Covers external plugins that still pass a serialized SDK Status object.
-      // The object status is not a recognized string so errorCode falls back to UNKNOWN;
-      // the error string is still surfaced correctly.
+      // Covers third-party plugins that pass a serialized SDK Status object rather than
+      // the normalised 'ERROR' string. The object is not a recognised string so
+      // errorCode falls back to UNKNOWN; the error string is still surfaced correctly.
       const result = classifyToolResult({
         raw: { status: { _code: 1 }, error: 'INVALID_TRANSACTION' },
         humanMessage: 'INVALID_TRANSACTION',

--- a/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
+++ b/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyToolResult,
+  transactionToolOutputParser,
+  type ToolResultStatus,
+} from '@/shared/utils/default-tool-output-parsing';
+
+describe('classifyToolResult', () => {
+  describe('success', () => {
+    it('classifies a SUCCESS-status envelope as success and lifts transactionId', () => {
+      const result = classifyToolResult({
+        raw: { status: 'SUCCESS', transactionId: '0.0.1234@1700000000.000000001' },
+        humanMessage:
+          'Message submitted successfully with transaction id 0.0.1234@1700000000.000000001',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.transactionId).toBe('0.0.1234@1700000000.000000001');
+        expect(result.humanMessage).toContain('Message submitted');
+        expect(result.data).toMatchObject({ status: 'SUCCESS' });
+      }
+    });
+
+    it('returns success with undefined transactionId when none is present', () => {
+      const result = classifyToolResult({
+        raw: { status: 'SUCCESS', topicId: '0.0.5678' },
+        humanMessage: 'Topic created',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.transactionId).toBeUndefined();
+      }
+    });
+
+    it('preserves the full raw payload via the typed `data` field', () => {
+      type CreateTopicData = { status: string; topicId: string; transactionId: string };
+      const result = classifyToolResult<CreateTopicData>({
+        raw: { status: 'SUCCESS', topicId: '0.0.5678', transactionId: '0.0.1@2.3' },
+        humanMessage: 'Topic created',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        // Type narrowing: data is typed as CreateTopicData here
+        expect(result.data.topicId).toBe('0.0.5678');
+        expect(result.data.transactionId).toBe('0.0.1@2.3');
+      }
+    });
+
+    it('treats RETURN_BYTES mode (no status field, has bytes) as success', () => {
+      const result = classifyToolResult({
+        raw: { bytes: new Uint8Array([1, 2, 3]) },
+        humanMessage: 'Transaction bytes are ready for signing.',
+      });
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.transactionId).toBeUndefined();
+        expect((result.data as { bytes: Uint8Array }).bytes).toBeInstanceOf(Uint8Array);
+      }
+    });
+  });
+
+  describe('failure', () => {
+    it('classifies an SDK Status object (e.g. InvalidTransaction) as failure with numeric code', () => {
+      const result = classifyToolResult({
+        raw: {
+          status: { _code: 1 },
+          error: 'Failed to submit message to topic: INVALID_TRANSACTION',
+        },
+        humanMessage: 'Failed to submit message to topic: INVALID_TRANSACTION',
+      });
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.errorCode).toBe(1);
+        expect(result.error).toContain('INVALID_TRANSACTION');
+        expect(result.humanMessage).toContain('Failed to submit');
+      }
+    });
+
+    it('falls back to humanMessage as `error` when raw.error is missing', () => {
+      const result = classifyToolResult({
+        raw: { status: { _code: 9 } },
+        humanMessage: 'something went wrong',
+      });
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.errorCode).toBe(9);
+        expect(result.error).toBe('something went wrong');
+      }
+    });
+
+    it('classifies envelope with raw.error string (no status object) as failure', () => {
+      const result = classifyToolResult({
+        raw: { error: 'Network unreachable' },
+        humanMessage: 'Network unreachable',
+      });
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.errorCode).toBe('UNKNOWN');
+        expect(result.error).toBe('Network unreachable');
+      }
+    });
+  });
+
+  describe('parse_error', () => {
+    it('classifies PARSE_ERROR-status envelopes as parse_error', () => {
+      const result = classifyToolResult({
+        raw: {
+          status: 'PARSE_ERROR',
+          error: new SyntaxError('Unexpected token'),
+          originalOutput: 'not-json{',
+        },
+        humanMessage: 'Error: Failed to parse tool output. The output was malformed.',
+      });
+
+      expect(result.kind).toBe('parse_error');
+      if (result.kind === 'parse_error') {
+        expect(result.originalOutput).toBe('not-json{');
+        expect(result.humanMessage).toContain('Failed to parse');
+      }
+    });
+
+    it('classifies missing/null raw as parse_error', () => {
+      const result = classifyToolResult({ raw: null as unknown as object, humanMessage: '' });
+      expect(result.kind).toBe('parse_error');
+    });
+
+    it('classifies non-object raw (string) as parse_error', () => {
+      const result = classifyToolResult({ raw: 'oops' as unknown as object, humanMessage: '' });
+      expect(result.kind).toBe('parse_error');
+      if (result.kind === 'parse_error') {
+        expect(result.originalOutput).toBe('oops');
+        expect(result.humanMessage).toContain('unexpected format');
+      }
+    });
+  });
+
+  describe('end-to-end with transactionToolOutputParser', () => {
+    it('classifies the parser output of a successful submit_topic_message_tool', () => {
+      // Shape produced by the kit when a transaction succeeds in EXECUTE_TRANSACTION mode.
+      const rawOutput = JSON.stringify({
+        raw: { status: 'SUCCESS', transactionId: '0.0.1234@1700.0' },
+        humanMessage: 'Message submitted successfully with transaction id 0.0.1234@1700.0',
+      });
+      const envelope = transactionToolOutputParser(rawOutput);
+      const result: ToolResultStatus = classifyToolResult(envelope);
+
+      expect(result.kind).toBe('success');
+      if (result.kind === 'success') {
+        expect(result.transactionId).toBe('0.0.1234@1700.0');
+      }
+    });
+
+    it('classifies a malformed parser input as parse_error end-to-end', () => {
+      const envelope = transactionToolOutputParser('not-json{');
+      const result = classifyToolResult(envelope);
+      expect(result.kind).toBe('parse_error');
+    });
+  });
+});

--- a/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
+++ b/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
@@ -7,11 +7,10 @@ import {
 
 describe('classifyToolResult', () => {
   describe('success', () => {
-    it('classifies a SUCCESS-status envelope as success and lifts transactionId', () => {
+    it('classifies SUCCESS status and lifts transactionId', () => {
       const result = classifyToolResult({
         raw: { status: 'SUCCESS', transactionId: '0.0.1234@1700000000.000000001' },
-        humanMessage:
-          'Message submitted successfully with transaction id 0.0.1234@1700000000.000000001',
+        humanMessage: 'Message submitted successfully with transaction id 0.0.1234@1700000000.000000001',
       });
 
       expect(result.kind).toBe('success');
@@ -22,7 +21,7 @@ describe('classifyToolResult', () => {
       }
     });
 
-    it('returns success with undefined transactionId when none is present', () => {
+    it('returns undefined transactionId when absent', () => {
       const result = classifyToolResult({
         raw: { status: 'SUCCESS', topicId: '0.0.5678' },
         humanMessage: 'Topic created',
@@ -34,7 +33,7 @@ describe('classifyToolResult', () => {
       }
     });
 
-    it('preserves the full raw payload via the typed `data` field', () => {
+    it('exposes typed data via generic parameter', () => {
       type CreateTopicData = { status: string; topicId: string; transactionId: string };
       const result = classifyToolResult<CreateTopicData>({
         raw: { status: 'SUCCESS', topicId: '0.0.5678', transactionId: '0.0.1@2.3' },
@@ -43,15 +42,14 @@ describe('classifyToolResult', () => {
 
       expect(result.kind).toBe('success');
       if (result.kind === 'success') {
-        // Type narrowing: data is typed as CreateTopicData here
         expect(result.data.topicId).toBe('0.0.5678');
         expect(result.data.transactionId).toBe('0.0.1@2.3');
       }
     });
 
-    it('treats RETURN_BYTES mode (no status field, has bytes) as success', () => {
+    it('classifies RETURN_BYTES mode (bytes + status SUCCESS) as success', () => {
       const result = classifyToolResult({
-        raw: { bytes: new Uint8Array([1, 2, 3]) },
+        raw: { bytes: new Uint8Array([1, 2, 3]), status: 'SUCCESS' },
         humanMessage: 'Transaction bytes are ready for signing.',
       });
 
@@ -61,40 +59,45 @@ describe('classifyToolResult', () => {
         expect((result.data as { bytes: Uint8Array }).bytes).toBeInstanceOf(Uint8Array);
       }
     });
+
+    it('status SUCCESS takes precedence over a present error field', () => {
+      const result = classifyToolResult({
+        raw: { status: 'SUCCESS', error: 'non-fatal warning' },
+        humanMessage: 'Done',
+      });
+
+      expect(result.kind).toBe('success');
+    });
   });
 
   describe('failure', () => {
-    it('classifies an SDK Status object (e.g. InvalidTransaction) as failure with numeric code', () => {
+    it('classifies ERROR status with error string', () => {
       const result = classifyToolResult({
-        raw: {
-          status: { _code: 1 },
-          error: 'Failed to submit message to topic: INVALID_TRANSACTION',
-        },
-        humanMessage: 'Failed to submit message to topic: INVALID_TRANSACTION',
+        raw: { status: 'ERROR', error: 'Failed to get account: not found' },
+        humanMessage: 'Failed to get account: not found',
       });
 
       expect(result.kind).toBe('failure');
       if (result.kind === 'failure') {
-        expect(result.errorCode).toBe(1);
-        expect(result.error).toContain('INVALID_TRANSACTION');
-        expect(result.humanMessage).toContain('Failed to submit');
+        expect(result.errorCode).toBe('ERROR');
+        expect(result.error).toBe('Failed to get account: not found');
       }
     });
 
-    it('falls back to humanMessage as `error` when raw.error is missing', () => {
+    it('falls back to humanMessage as error when error field is absent', () => {
       const result = classifyToolResult({
-        raw: { status: { _code: 9 } },
+        raw: { status: 'ERROR' },
         humanMessage: 'something went wrong',
       });
 
       expect(result.kind).toBe('failure');
       if (result.kind === 'failure') {
-        expect(result.errorCode).toBe(9);
+        expect(result.errorCode).toBe('ERROR');
         expect(result.error).toBe('something went wrong');
       }
     });
 
-    it('classifies envelope with raw.error string (no status object) as failure', () => {
+    it('classifies error string with no status as failure with UNKNOWN code', () => {
       const result = classifyToolResult({
         raw: { error: 'Network unreachable' },
         humanMessage: 'Network unreachable',
@@ -106,10 +109,26 @@ describe('classifyToolResult', () => {
         expect(result.error).toBe('Network unreachable');
       }
     });
+
+    it('classifies object status with error string as failure with UNKNOWN code', () => {
+      // Covers external plugins that still pass a serialized SDK Status object.
+      // The object status is not a recognized string so errorCode falls back to UNKNOWN;
+      // the error string is still surfaced correctly.
+      const result = classifyToolResult({
+        raw: { status: { _code: 1 }, error: 'INVALID_TRANSACTION' },
+        humanMessage: 'INVALID_TRANSACTION',
+      });
+
+      expect(result.kind).toBe('failure');
+      if (result.kind === 'failure') {
+        expect(result.errorCode).toBe('UNKNOWN');
+        expect(result.error).toBe('INVALID_TRANSACTION');
+      }
+    });
   });
 
   describe('parse_error', () => {
-    it('classifies PARSE_ERROR-status envelopes as parse_error', () => {
+    it('classifies PARSE_ERROR status as parse_error and surfaces originalOutput', () => {
       const result = classifyToolResult({
         raw: {
           status: 'PARSE_ERROR',
@@ -126,12 +145,12 @@ describe('classifyToolResult', () => {
       }
     });
 
-    it('classifies missing/null raw as parse_error', () => {
+    it('classifies null raw as parse_error', () => {
       const result = classifyToolResult({ raw: null as unknown as object, humanMessage: '' });
       expect(result.kind).toBe('parse_error');
     });
 
-    it('classifies non-object raw (string) as parse_error', () => {
+    it('classifies non-object raw as parse_error and surfaces the value', () => {
       const result = classifyToolResult({ raw: 'oops' as unknown as object, humanMessage: '' });
       expect(result.kind).toBe('parse_error');
       if (result.kind === 'parse_error') {
@@ -141,9 +160,40 @@ describe('classifyToolResult', () => {
     });
   });
 
+  describe('unknown', () => {
+    it('classifies unrecognized string status with no error as unknown', () => {
+      const result = classifyToolResult({
+        raw: { status: 'FAILED' },
+        humanMessage: 'something happened',
+      });
+
+      expect(result.kind).toBe('unknown');
+      if (result.kind === 'unknown') {
+        expect(result.humanMessage).toBe('something happened');
+      }
+    });
+
+    it('classifies object status with no error as unknown', () => {
+      const result = classifyToolResult({
+        raw: { status: { _code: 9 } },
+        humanMessage: 'something went wrong',
+      });
+
+      expect(result.kind).toBe('unknown');
+    });
+
+    it('classifies raw with no status and no error as unknown', () => {
+      const result = classifyToolResult({
+        raw: { someOtherField: 'value' },
+        humanMessage: 'unexpected shape',
+      });
+
+      expect(result.kind).toBe('unknown');
+    });
+  });
+
   describe('end-to-end with transactionToolOutputParser', () => {
-    it('classifies the parser output of a successful submit_topic_message_tool', () => {
-      // Shape produced by the kit when a transaction succeeds in EXECUTE_TRANSACTION mode.
+    it('classifies a successful EXECUTE_TRANSACTION output', () => {
       const rawOutput = JSON.stringify({
         raw: { status: 'SUCCESS', transactionId: '0.0.1234@1700.0' },
         humanMessage: 'Message submitted successfully with transaction id 0.0.1234@1700.0',
@@ -157,7 +207,7 @@ describe('classifyToolResult', () => {
       }
     });
 
-    it('classifies a malformed parser input as parse_error end-to-end', () => {
+    it('classifies malformed parser input as parse_error', () => {
       const envelope = transactionToolOutputParser('not-json{');
       const result = classifyToolResult(envelope);
       expect(result.kind).toBe('parse_error');

--- a/packages/core/tests/unit/utils/decimals-utils.unit.test.ts
+++ b/packages/core/tests/unit/utils/decimals-utils.unit.test.ts
@@ -66,42 +66,30 @@ describe('decimals-utils', () => {
   });
 
   describe('getERC20Decimals', () => {
+    const callContractMock = vi.fn();
     const mockMirrorNode = {
       getContractInfo: vi.fn().mockResolvedValue({ evm_address: '0xabc' }),
-      getBaseUrl: () => 'https://mirror.example/api/v1',
+      callContract: callContractMock,
     } as any;
 
     afterEach(() => {
-      vi.unstubAllGlobals();
+      vi.clearAllMocks();
     });
 
     it('reads decimals via the mirror node contracts/call endpoint', async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          result: '0x0000000000000000000000000000000000000000000000000000000000000012',
-        }),
-      });
-      vi.stubGlobal('fetch', fetchMock);
+      callContractMock.mockResolvedValue(
+        '0x0000000000000000000000000000000000000000000000000000000000000012',
+      );
 
       await expect(getERC20Decimals('0.0.5678', mockMirrorNode)).resolves.toBe(18);
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://mirror.example/api/v1/contracts/call',
-        expect.objectContaining({
-          method: 'POST',
-          body: JSON.stringify({ data: '0x313ce567', to: '0xabc' }),
-        }),
-      );
+      expect(callContractMock).toHaveBeenCalledWith('0xabc', '0x313ce567');
     });
 
     it('throws when the contract call fails', async () => {
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue({ ok: false, status: 400, statusText: 'Bad Request' }),
-      );
+      callContractMock.mockRejectedValue(new Error('400 Bad Request'));
 
       await expect(getERC20Decimals('0.0.5678', mockMirrorNode)).rejects.toThrow(
-        'Failed to read decimals of ERC20 contract 0.0.5678: 400 Bad Request',
+        '400 Bad Request',
       );
     });
   });

--- a/packages/core/tests/unit/utils/tool-output-parsing.unit.test.ts
+++ b/packages/core/tests/unit/utils/tool-output-parsing.unit.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+  transactionToolOutputParser,
+  untypedQueryOutputParser,
+  classifyToolResult,
+} from '@hashgraph/hedera-agent-kit';
+
+describe('transactionToolOutputParser', () => {
+  it('returns PARSE_ERROR on malformed JSON', () => {
+    const result = transactionToolOutputParser('not json');
+    expect(result.raw.status).toBe('PARSE_ERROR');
+  });
+
+  it('returns PARSE_ERROR on unrecognized envelope shape', () => {
+    const result = transactionToolOutputParser(JSON.stringify({ foo: 'bar' }));
+    expect(result.raw.status).toBe('PARSE_ERROR');
+  });
+
+  it('passes through RETURN_BYTES result unchanged (status set by ReturnBytesStrategy)', () => {
+    // ReturnBytesStrategy now sets status: 'SUCCESS' before serialization;
+    // the parser passes it through without injecting anything itself.
+    const input = JSON.stringify({ bytes: [1, 2, 3], status: 'SUCCESS' });
+    const result = transactionToolOutputParser(input);
+    expect(result.raw.status).toBe('SUCCESS');
+    expect(result.raw.bytes).toBeDefined();
+  });
+
+  it('passes through EXECUTE_TRANSACTION success unchanged', () => {
+    const input = JSON.stringify({
+      raw: { status: 'SUCCESS', transactionId: '0.0.1@1234' },
+      humanMessage: 'Done',
+    });
+    const result = transactionToolOutputParser(input);
+    expect(result.raw.status).toBe('SUCCESS');
+    expect(result.raw.transactionId).toBe('0.0.1@1234');
+    expect(result.humanMessage).toBe('Done');
+  });
+
+  it('passes through EXECUTE_TRANSACTION error shape unchanged', () => {
+    const input = JSON.stringify({
+      raw: { status: { _code: 10 }, error: 'Failed to execute' },
+      humanMessage: 'Failed to execute',
+    });
+    const result = transactionToolOutputParser(input);
+    expect(result.raw.error).toBe('Failed to execute');
+  });
+});
+
+describe('untypedQueryOutputParser', () => {
+  it('returns PARSE_ERROR on malformed JSON', () => {
+    const result = untypedQueryOutputParser('not json');
+    expect(result.raw.status).toBe('PARSE_ERROR');
+  });
+
+  it('returns PARSE_ERROR when envelope is missing raw or humanMessage', () => {
+    const result = untypedQueryOutputParser(JSON.stringify({ data: 42 }));
+    expect(result.raw.status).toBe('PARSE_ERROR');
+  });
+
+  it('passes through query success raw unchanged (status set by the tool coreAction)', () => {
+    // Query tools now set status: 'SUCCESS' in their coreAction; the parser is passive.
+    const input = JSON.stringify({
+      raw: { current_rate: { cent_equivalent: 300 }, timestamp: '123', status: 'SUCCESS' },
+      humanMessage: 'Rate fetched',
+    });
+    const result = untypedQueryOutputParser(input);
+    expect(result.raw.status).toBe('SUCCESS');
+    expect(result.raw.current_rate.cent_equivalent).toBe(300);
+  });
+
+  it('passes through query error raw unchanged', () => {
+    const input = JSON.stringify({
+      raw: { status: 'ERROR', error: 'Failed to get rate' },
+      humanMessage: 'Failed to get rate',
+    });
+    const result = untypedQueryOutputParser(input);
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.error).toBe('Failed to get rate');
+  });
+});
+
+describe('classifyToolResult', () => {
+  it('classifies executed transaction success', () => {
+    expect(
+      classifyToolResult({
+        raw: { status: 'SUCCESS', transactionId: '0.0.1@1234' },
+        humanMessage: 'Done',
+      }),
+    ).toMatchObject({ kind: 'success' });
+  });
+
+  it('classifies RETURN_BYTES success (status set by ReturnBytesStrategy)', () => {
+    expect(
+      classifyToolResult({
+        raw: { bytes: new Uint8Array([1, 2, 3]), status: 'SUCCESS' },
+        humanMessage: 'Transaction bytes are ready for signing.',
+      }),
+    ).toMatchObject({ kind: 'success' });
+  });
+
+  it('classifies query tool success (status set by coreAction)', () => {
+    expect(
+      classifyToolResult({
+        raw: { current_rate: { cent_equivalent: 300 }, status: 'SUCCESS' },
+        humanMessage: 'Rate fetched',
+      }),
+    ).toMatchObject({ kind: 'success' });
+  });
+
+  it('classifies parse error', () => {
+    expect(
+      classifyToolResult({
+        raw: { status: 'PARSE_ERROR', error: 'bad json', originalOutput: '...' },
+        humanMessage: 'Error: Failed to parse tool output.',
+      }),
+    ).toMatchObject({ kind: 'parse_error' });
+  });
+
+  it('classifies query tool error (string ERROR status + error field)', () => {
+    expect(
+      classifyToolResult({
+        raw: { status: 'ERROR', error: 'Failed to get account' },
+        humanMessage: 'Failed to get account',
+      }),
+    ).toMatchObject({ kind: 'failure' });
+  });
+
+  it('classifies BaseTool.handleError output (ERROR status + error field)', () => {
+    expect(
+      classifyToolResult({
+        raw: { status: 'ERROR', error: 'Failed to execute tool' },
+        humanMessage: 'Failed to execute tool',
+      }),
+    ).toMatchObject({ kind: 'failure' });
+  });
+
+  it('classifies custom transaction tool handleError output (serialized SDK Status + error)', () => {
+    expect(
+      classifyToolResult({
+        raw: { status: { _code: 10 }, error: 'Failed to submit' },
+        humanMessage: 'Failed to submit',
+      }),
+    ).toMatchObject({ kind: 'failure' });
+  });
+
+  it('classifies unrecognized string status with no error as unknown — not success', () => {
+    // This is the gap case: a tool returning { status: 'FAILED' } without an
+    // error field would have silently passed as success before this fix.
+    expect(
+      classifyToolResult({
+        raw: { status: 'FAILED' },
+        humanMessage: 'Something went wrong',
+      }),
+    ).toMatchObject({ kind: 'unknown' });
+  });
+
+  it('classifies null raw as parse_error', () => {
+    expect(classifyToolResult({ raw: null as any, humanMessage: '' })).toMatchObject({
+      kind: 'parse_error',
+    });
+  });
+
+  it('parse_error takes precedence over failure when both status and error are present', () => {
+    // parse errors set both status: 'PARSE_ERROR' and error — PARSE_ERROR wins
+    expect(
+      classifyToolResult({
+        raw: { status: 'PARSE_ERROR', error: 'bad', originalOutput: '' },
+        humanMessage: '',
+      }),
+    ).toMatchObject({ kind: 'parse_error' });
+  });
+});

--- a/packages/core/tests/unit/utils/tool-output-parsing.unit.test.ts
+++ b/packages/core/tests/unit/utils/tool-output-parsing.unit.test.ts
@@ -3,7 +3,7 @@ import {
   transactionToolOutputParser,
   untypedQueryOutputParser,
   classifyToolResult,
-} from '@hashgraph/hedera-agent-kit';
+} from '@/shared/utils/default-tool-output-parsing';
 
 describe('transactionToolOutputParser', () => {
   it('returns PARSE_ERROR on malformed JSON', () => {
@@ -125,22 +125,42 @@ describe('classifyToolResult', () => {
     ).toMatchObject({ kind: 'failure' });
   });
 
-  it('classifies BaseTool.handleError output (ERROR status + error field)', () => {
+  it('classifies BaseTool.handleError generic output (ERROR status + error field)', () => {
     expect(
       classifyToolResult({
         raw: { status: 'ERROR', error: 'Failed to execute tool' },
         humanMessage: 'Failed to execute tool',
       }),
-    ).toMatchObject({ kind: 'failure' });
+    ).toMatchObject({ kind: 'failure', errorCode: 'ERROR' });
   });
 
-  it('classifies custom transaction tool handleError output (serialized SDK Status + error)', () => {
+  it('classifies BaseTool.handleError ReceiptStatusError output — errorCode is SDK status name', () => {
+    // BaseTool.handleError() detects ReceiptStatusError and sets errorCode to the
+    // SDK status name so callers get the specific network-level failure reason.
+    expect(
+      classifyToolResult({
+        raw: {
+          status: 'ERROR',
+          errorCode: 'INSUFFICIENT_PAYER_BALANCE',
+          transactionId: '0.0.1@1700000000.000000001',
+          error:
+            'receipt for transaction 0.0.1@1700000000.000000001 contained error status INSUFFICIENT_PAYER_BALANCE',
+        },
+        humanMessage:
+          'receipt for transaction 0.0.1@1700000000.000000001 contained error status INSUFFICIENT_PAYER_BALANCE',
+      }),
+    ).toMatchObject({ kind: 'failure', errorCode: 'INSUFFICIENT_PAYER_BALANCE' });
+  });
+
+  it('classifies third-party plugin output with serialized SDK Status object as failure with UNKNOWN code', () => {
+    // Third-party plugins may still return a serialized SDK Status object in raw.status.
+    // The object is not a recognised string so errorCode falls back to UNKNOWN.
     expect(
       classifyToolResult({
         raw: { status: { _code: 10 }, error: 'Failed to submit' },
         humanMessage: 'Failed to submit',
       }),
-    ).toMatchObject({ kind: 'failure' });
+    ).toMatchObject({ kind: 'failure', errorCode: 'UNKNOWN' });
   });
 
   it('classifies unrecognized string status with no error as unknown — not success', () => {

--- a/packages/langchain/src/responseParserService.ts
+++ b/packages/langchain/src/responseParserService.ts
@@ -6,7 +6,7 @@ function convertBytes(data: any): any {
     return { ...data, raw: { ...data.raw, bytes: new Uint8Array(data.raw.bytes.data) } };
   }
   if (data?.bytes && typeof data.bytes === 'object' && data.bytes.type === 'Buffer') {
-    return { bytes: new Uint8Array(data.bytes.data) };
+    return { ...data, bytes: new Uint8Array(data.bytes.data) };
   }
   return data;
 }

--- a/packages/langchain/tests/e2e/dissociate-token.e2e.test.ts
+++ b/packages/langchain/tests/e2e/dissociate-token.e2e.test.ts
@@ -186,7 +186,7 @@ describe('Airdrop Fungible Token E2E Tests', () => {
 
       const parsedResponse = responseParsingService.parseNewToolMessages(queryResult);
 
-      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to dissociate');
+      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to execute Dissociate Token');
       expect(parsedResponse[0].parsedData.raw.status).not.toBe('SUCCESS');
     },
   );
@@ -205,7 +205,7 @@ describe('Airdrop Fungible Token E2E Tests', () => {
 
       const parsedResponse = responseParsingService.parseNewToolMessages(queryResult);
 
-      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to dissociate');
+      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to execute Dissociate Token');
       expect(parsedResponse[0].parsedData.raw.status).not.toBe('SUCCESS');
     },
   );

--- a/packages/langchain/tests/e2e/get-contract-info-query.e2e.test.ts
+++ b/packages/langchain/tests/e2e/get-contract-info-query.e2e.test.ts
@@ -80,8 +80,8 @@ describe('Get Contract Info E2E Tests', () => {
       });
       const parsedResponse = responseParsingService.parseNewToolMessages(queryResult);
 
-      expect(parsedResponse[0].parsedData.raw.error).toContain('Failed to get contract info');
-      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to get contract info');
+      expect(parsedResponse[0].parsedData.raw.error).toContain('Failed to execute Get Contract Info');
+      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to execute Get Contract Info');
     },
   );
 });

--- a/packages/langchain/tests/e2e/get-token-info-query.e2e.test.ts
+++ b/packages/langchain/tests/e2e/get-token-info-query.e2e.test.ts
@@ -177,7 +177,7 @@ describe('Get Token Info Query E2E Tests', () => {
 
       const parsedResponse = responseParsingService.parseNewToolMessages(result);
 
-      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to get token info');
+      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to execute Get Token Info');
       expect(parsedResponse[0].parsedData.raw.error).toBeDefined();
     },
   );

--- a/packages/langchain/tests/e2e/get-transaction-record.e2e.test.ts
+++ b/packages/langchain/tests/e2e/get-transaction-record.e2e.test.ts
@@ -115,10 +115,10 @@ describe('Get Transaction Record E2E Tests', () => {
       const parsedResponse = responseParsingService.parseNewToolMessages(result);
 
       expect(parsedResponse).toBeDefined();
-      expect(parsedResponse[0].parsedData.raw.error).toContain('Failed to get transaction record');
+      expect(parsedResponse[0].parsedData.raw.error).toContain('Failed to execute Get Transaction Record Query');
       expect(parsedResponse[0].parsedData.raw.error).toContain('Not Found');
       expect(parsedResponse[0].parsedData.humanMessage).toContain(
-        'Failed to get transaction record',
+        'Failed to execute Get Transaction Record Query',
       );
       expect(parsedResponse[0].parsedData.humanMessage).toContain('Not Found');
     },
@@ -144,9 +144,9 @@ describe('Get Transaction Record E2E Tests', () => {
       expect(parsedResponse[0].parsedData.raw.error).toContain(
         'Invalid transactionId format: invalid-tx-id',
       );
-      expect(parsedResponse[0].parsedData.raw.error).toContain('Failed to get transaction record');
+      expect(parsedResponse[0].parsedData.raw.error).toContain('Failed to execute Get Transaction Record Query');
       expect(parsedResponse[0].parsedData.humanMessage).toContain(
-        'Failed to get transaction record',
+        'Failed to execute Get Transaction Record Query',
       );
     },
   );

--- a/packages/langchain/tests/e2e/sign-schedule-transaction.e2e.test.ts
+++ b/packages/langchain/tests/e2e/sign-schedule-transaction.e2e.test.ts
@@ -111,7 +111,7 @@ describe('Sign Schedule Transaction E2E Tests', () => {
       const parsedResponse = responseParsingService.parseNewToolMessages(result);
       // Should handle the error gracefully
       expect(parsedResponse[0].parsedData.humanMessage).toContain(
-        'Failed to sign scheduled transaction',
+        'Failed to execute Sign Scheduled Transaction',
       );
     },
   );

--- a/packages/langchain/tests/e2e/transfer-erc20.e2e.test.ts
+++ b/packages/langchain/tests/e2e/transfer-erc20.e2e.test.ts
@@ -6,10 +6,11 @@ import {
   HederaOperationsWrapper,
   type TestAccount,
   waitForMirrorTx,
+  waitFor,
 } from '@hashgraph/hedera-agent-kit-tests';
 import { ResponseParserService } from '@hashgraph/hedera-agent-kit-langchain';
 import { Client } from '@hiero-ledger/sdk';
-import { createERC20Parameters } from '@hashgraph/hedera-agent-kit';
+import { createERC20Parameters, getMirrornodeService, getERC20Decimals } from '@hashgraph/hedera-agent-kit';
 import { z } from 'zod';
 
 describe('Transfer ERC20 Token E2E Tests', () => {
@@ -52,6 +53,19 @@ describe('Transfer ERC20 Token E2E Tests', () => {
 
     testTokenAddress = createResult.erc20Address;
     await waitForMirrorTx(executorWrapper, createResult.raw.transactionId);
+
+    const mirrorNode = getMirrornodeService(undefined, executorClient.ledgerId!);
+    await waitFor(
+      async () => {
+        try {
+          await getERC20Decimals(testTokenAddress, mirrorNode);
+          return true;
+        } catch {
+          return null;
+        }
+      },
+      { timeoutMs: 15000, intervalMs: 500, description: 'ERC20 contract to be callable' },
+    );
   });
 
   afterAll(async () => {

--- a/packages/langchain/tests/e2e/transfer-erc721.e2e.test.ts
+++ b/packages/langchain/tests/e2e/transfer-erc721.e2e.test.ts
@@ -159,7 +159,7 @@ describe('Transfer ERC721 Token E2E Tests', () => {
       const parsedResponse = responseParsingService.parseNewToolMessages(result);
 
       expect(parsedResponse).toBeDefined();
-      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to transfer ERC721');
+      expect(parsedResponse[0].parsedData.humanMessage).toContain('Failed to execute Transfer ERC721');
     },
   );
 });

--- a/packages/langchain/tests/e2e/transfer-fungible-token-with-allowance.e2e.test.ts
+++ b/packages/langchain/tests/e2e/transfer-fungible-token-with-allowance.e2e.test.ts
@@ -212,7 +212,7 @@ describe('Transfer Fungible Token With Allowance E2E Tests', () => {
     const parsedResponse = responseParsingService.parseNewToolMessages(result);
 
     expect(parsedResponse[0].parsedData.humanMessage).toContain(
-      'Failed to transfer fungible token with allowance',
+      'Failed to execute Transfer Fungible Token with Allowance',
     );
     expect(parsedResponse[0].parsedData.humanMessage).toContain('AMOUNT_EXCEEDS_ALLOWANCE');
   });

--- a/packages/langchain/tests/e2e/update-token.e2e.test.ts
+++ b/packages/langchain/tests/e2e/update-token.e2e.test.ts
@@ -118,10 +118,10 @@ describe('Get Token Info Query E2E Tests', () => {
       const parsedResponse = responseParsingService.parseNewToolMessages(queryResult);
 
       expect(parsedResponse[0].parsedData.humanMessage).toContain(
-        'Failed to update token: Cannot update kycKey: token was created without a kycKey',
+        'Failed to execute Update Token: Cannot update kycKey: token was created without a kycKey',
       );
       expect(parsedResponse[0].parsedData.raw.error).toContain(
-        'Failed to update token: Cannot update kycKey: token was created without a kycKey',
+        'Failed to execute Update Token: Cannot update kycKey: token was created without a kycKey',
       );
     },
   );

--- a/packages/langchain/tests/e2e/update-token.e2e.test.ts
+++ b/packages/langchain/tests/e2e/update-token.e2e.test.ts
@@ -47,7 +47,7 @@ describe('Get Token Info Query E2E Tests', () => {
       autoRenewAccountId: executor.accountId.toString(),
       adminKey: executor.privateKey.publicKey as PublicKey,
       treasuryAccountId: executor.accountId.toString(),
-      metadataKey: profile.operator.privateKey.publicKey as PublicKey,
+      metadataKey: executor.privateKey.publicKey as PublicKey,
     });
     tokenIdFT = createTokenResp.tokenId!;
 

--- a/packages/langchain/tests/e2e/update-topic.e2e.test.ts
+++ b/packages/langchain/tests/e2e/update-topic.e2e.test.ts
@@ -120,10 +120,10 @@ describe('Update Topic E2E Tests', () => {
       const parsedResponse = responseParsingService.parseNewToolMessages(queryResult);
 
       expect(parsedResponse[0].parsedData.humanMessage).toContain(
-        'Failed to update topic: Cannot update submitKey: topic was created without a submitKey',
+        'Failed to execute Update Topic: Cannot update submitKey: topic was created without a submitKey',
       );
       expect(parsedResponse[0].parsedData.raw.error).toContain(
-        'Failed to update topic: Cannot update submitKey: topic was created without a submitKey',
+        'Failed to execute Update Topic: Cannot update submitKey: topic was created without a submitKey',
       );
     },
   );

--- a/packages/tests/shared/hedera-operations/HederaOperationsWrapper.ts
+++ b/packages/tests/shared/hedera-operations/HederaOperationsWrapper.ts
@@ -15,6 +15,7 @@ import {
   TopicInfoQuery,
   TransactionRecordQuery,
   TransferTransaction,
+  Hbar,
 } from '@hiero-ledger/sdk';
 import BigNumber from 'bignumber.js';
 import { getTestLedgerIdForTests } from '../profile/resolve';
@@ -310,8 +311,11 @@ class HederaOperationsWrapper {
 
   async deployERC20(bytecode: string) {
     try {
-      const tx = new ContractCreateFlow().setGas(3_000_000).setBytecode(bytecode);
+      const tx = new ContractCreateFlow()
+        .setGas(3_000_000)
+        .setBytecode(bytecode);
 
+      this.client.setDefaultMaxTransactionFee(new Hbar(100));
       const response = await tx.execute(this.client);
       const receipt = await response.getReceipt(this.client);
 


### PR DESCRIPTION
# Tool Result Status

## What changed

### New: `TOOL_STATUS` const — single source of truth for status strings

A shared constant replaces every bare `'SUCCESS'` / `'ERROR'` / `'PARSE_ERROR'` string literal at every write and read site:

```typescript
export const TOOL_STATUS = {
  SUCCESS: 'SUCCESS',
  ERROR: 'ERROR',
  PARSE_ERROR: 'PARSE_ERROR',
} as const;

export type ToolRawStatus = (typeof TOOL_STATUS)[keyof typeof TOOL_STATUS];
```

`ToolRawStatus` is now derived from the const, so the type and the runtime values are always in sync. A typo like `TOOL_STATUS.SUCESS` is a compile error; the string `'SUCESS'` was not. `TOOL_STATUS` is exported from `@hashgraph/hedera-agent-kit` for plugin authors.

---

### New: `classifyToolResult` and `ToolResultStatus<T>` — created by @sneldao

`classifyToolResult` takes the `{ raw, humanMessage }` envelope returned by `transactionToolOutputParser` or `untypedQueryOutputParser` and maps it to a typed discriminated union:

```typescript
type ToolResultStatus<T = unknown> =
  | { kind: 'success';     transactionId?: string; data: T; humanMessage: string }
  | { kind: 'failure';     errorCode: string; transactionId?: string; error: string; humanMessage: string }
  | { kind: 'parse_error'; originalOutput: unknown; humanMessage: string }
  | { kind: 'unknown';     humanMessage: string }
```

Classification rules:

| `raw.status` | `raw.errorCode` | `raw.error` | `kind` | `errorCode` |
|---|---|---|---|---|
| `'SUCCESS'` | — | — | `success` | — |
| `'ERROR'` | `'INSUFFICIENT_PAYER_BALANCE'` (SDK status string) | string | `failure` | `'INSUFFICIENT_PAYER_BALANCE'` |
| `'ERROR'` | absent | string | `failure` | `'ERROR'` |
| `'PARSE_ERROR'` | — | — | `parse_error` | — |
| anything else | — | absent | `unknown` | — |
| `null` / non-object | — | — | `parse_error` | — |

`errorCode` is populated from `raw.errorCode` when present (the specific Hedera SDK status name for receipt/precheck failures), otherwise falls back to `raw.status`. `transactionId` is lifted out of `raw` for both `success` and `failure` kinds — receipt and precheck errors both set it.

`kind: 'unknown'` exists specifically to prevent unrecognized shapes from silently falling through to `success`.

---

### Changed: `status: 'SUCCESS'` is now defaulted centrally in `BaseTool.execute`

`classifyToolResult` requires `raw.status === 'SUCCESS'` to return `kind: 'success'`. Instead of requiring every tool to set it explicitly, `BaseTool.execute()` now defaults it with `??=` after the success pipeline completes:

```typescript
// In BaseTool.execute(), after secondaryAction:
if (result && typeof result.raw === 'object' && result.raw !== null) {
  result.raw.status ??= TOOL_STATUS.SUCCESS;
}
```

`??=` preserves any explicit status already set upstream (`ExecuteStrategy`, `ReturnBytesStrategy`). Query tools and third-party tools that return a `raw` envelope without a `status` field now get `'SUCCESS'` for free.

---

### Changed: `handleError` standardized to `status: 'ERROR'`

All `handleError` implementations previously used `Status.InvalidTransaction` (an SDK receipt-level object) for pre-flight errors — errors that occur before a transaction is ever submitted. This was semantically wrong and inconsistent after JSON round-trip (`Status.InvalidTransaction` serializes as `{ _code: 1 }`, not as a string).

All tools now return a plain string via `TOOL_STATUS.ERROR`:

```typescript
return { raw: { status: TOOL_STATUS.ERROR, error: message }, humanMessage: message };
```

Affected:
- `BaseTool.handleError` (base class)
- All 10 query tool `handleError` overrides — **deleted** (see below)
- All 33 transaction tool `handleError` overrides — **deleted** (see `BaseTransactionTool` below)

The unused `Status` import was removed from all affected files.

---

### New: `BaseTransactionTool` — structured `ReceiptStatusError` and `PrecheckStatusError` fields

A new abstract class `BaseTransactionTool extends BaseTool` was introduced in `packages/core/src/shared/base-transaction-tool.ts`. It owns the Hedera-specific error handling that previously lived (in an incomplete, prose-only form) in each of the 33 transaction tools.

**Why**

- `BaseTool` is a generic framework primitive that third-party plugins can extend. Baking Hedera SDK knowledge into it leaked SDK types into the generic base and would force every plugin author to depend on `@hiero-ledger/sdk` transitively.
- Before, when a transaction failed on-network or at the precheck stage, callers received a prose `humanMessage` and had to regex-parse it to recover the SDK status name and transaction ID. Both are already structured on the error — they should be surfaced directly.
- `INSUFFICIENT_PAYER_BALANCE` typically surfaces as a `PrecheckStatusError` (the node rejects the transaction before it reaches consensus), not a `ReceiptStatusError`. The previous implementation only handled `ReceiptStatusError`, so `errorCode` and `transactionId` were silently lost for the most common balance failure.
- The 33 transaction tools each carried a near-identical `handleError` override. That's boilerplate duplication and an easy source of drift.

**What the class does**

When `execute()` throws a `ReceiptStatusError` or `PrecheckStatusError`, `BaseTransactionTool.handleError`:

- Sets `raw.status = TOOL_STATUS.ERROR`
- Sets `raw.errorCode = error.status.toString()` — the SDK status **name**, e.g. `'INSUFFICIENT_PAYER_BALANCE'`, `'TOKEN_NOT_ASSOCIATED_TO_ACCOUNT'`, `'INVALID_SCHEDULE_ID'`
- Sets `raw.transactionId = error.transactionId.toString()` — e.g. `'0.0.9414979@1783085748.874255414'`
- Sets `raw.error = error.message` — the raw SDK message, no prefix, machine-readable
- Sets `humanMessage = "Failed to execute ${this.name}: ${error.message}"` — human-facing, prefixed with the tool name

For any other error type it falls through to `super.handleError(error, context)` (the generic `BaseTool` path).

**How it lands in the codebase**

- `BaseTool.handleError` no longer imports or references `ReceiptStatusError` or `PrecheckStatusError`. It's purely generic.
- All 33 transaction tools now `extends BaseTransactionTool` (instead of `BaseTool`) and their per-tool `handleError` overrides were removed — the shared implementation covers every case.
- Query tools and any other non-transaction tools continue to extend `BaseTool` directly. Their `handleError` overrides were also removed (they were identical to the base).
- Exports: `BaseTransactionTool` is re-exported from `packages/core/src/index.ts` for plugin authors.

**How to use the structured fields**

```typescript
const envelope = transactionToolOutputParser(rawOutput);
const result = classifyToolResult<{ transactionId: string }>(envelope);

switch (result.kind) {
  case 'success':
    return { txId: result.transactionId };
  case 'failure':
    // result.errorCode === 'INSUFFICIENT_PAYER_BALANCE' for receipt/precheck balance failures
    // result.transactionId is available for receipt/precheck failures
    // result.errorCode === 'ERROR' for generic pre-flight throws
    if (result.errorCode === 'INSUFFICIENT_PAYER_BALANCE') {
      await topUpPayer();
    }
    throw new Error(`tool failed (${result.errorCode}): ${result.error}`);
}
```

Or, without `classifyToolResult`, read `raw.errorCode` and `raw.transactionId` directly.

---

### Changed: query tool `handleError` overrides deleted

All 10 query tool `handleError` overrides were deleted — they were behaviorally identical to `BaseTool.handleError` after this PR's changes. Query tools now inherit the base implementation directly, mirroring what the transaction tools do via `BaseTransactionTool`.

Affected tools:
- `get-account-query`
- `get-account-token-balances-query`
- `get-hbar-balance-query`
- `get-token-info-query`
- `get-pending-airdrop-query`
- `get-exchange-rate-query`
- `get-transaction-record-query`
- `get-topic-info-query`
- `get-topic-messages-query`
- `get-contract-info-query`

---

### Changed: `raw.error` is the raw SDK message; `humanMessage` carries the prefix

Previously the `handleError` overrides on transaction tools set `raw.error` and `humanMessage` to the **same** prefixed string (e.g. `"Failed to transfer HBAR: receipt for transaction ... INSUFFICIENT_PAYER_BALANCE"`). After the `BaseTransactionTool` change, on the `ReceiptStatusError` / `PrecheckStatusError` path only:

- `raw.error` = the raw SDK message (`"receipt for transaction ... INSUFFICIENT_PAYER_BALANCE"`) — machine-readable, no tool-name prefix.
- `humanMessage` = the prefixed message (`"Failed to execute Transfer HBAR: receipt for transaction ... INSUFFICIENT_PAYER_BALANCE"`) — human-facing.

On the generic-error path (via `BaseTool.handleError`), both fields still carry the prefixed message.

---

### Changed: transaction tool `humanMessage` wording is now uniform

Because per-tool `handleError` overrides were removed, transaction failure `humanMessage`s now share a single template: `"Failed to execute ${this.name}: ${error.message}"`. Previously each tool phrased its own prefix (`"Failed to dissociate"`, `"Failed to transfer HBAR"`, `"Failed to sign scheduled transaction"`, etc.). The new form always starts with `"Failed to execute "` followed by the exact `name` field on the tool (e.g. `"Failed to execute Dissociate Token"`, `"Failed to execute Sign Scheduled Transaction"`).

Integration and e2e tests that asserted on the old per-tool prose were updated accordingly.

---

### Fixed: `convertBytes` in `responseParserService.ts` preserves sibling fields

The top-level-`bytes` branch of `convertBytes` previously returned only `{ bytes: … }`, discarding sibling fields including `status`. It now spreads `data` to preserve all fields:

```typescript
// Before
return { bytes: new Uint8Array(data.bytes.data) };
// After
return { ...data, bytes: new Uint8Array(data.bytes.data) };
```

This matches the behaviour of the nested `data.raw.bytes` branch, which already spread correctly.

---

### Fixed: migration doc example updated

The `handleError` example in `docs/MIGRATION-v4.md` previously showed `status: Status.InvalidTransaction`, which no longer matches the contract. It now shows `status: 'ERROR'`.

---

## Potential breaking changes

### External tools that do not set `status: 'SUCCESS'`

Any custom tool whose `coreAction` or `secondaryAction` returns a `raw` object without `status: 'SUCCESS'` will now have it automatically set to `'SUCCESS'` by `BaseTool.execute()` (via `??=`). This is the **desired** behaviour — the `??=` preserves any explicit status a tool does set. However, a tool that intentionally returns a non-SUCCESS non-ERROR status would have that status overwritten.
**Who is affected:** Plugin authors with custom `BaseTool` subclasses that intentionally return a non-standard `raw.status` value on the success path.
**Fix:** Use `TOOL_STATUS.ERROR` or `TOOL_STATUS.PARSE_ERROR` for non-success outcomes — the `??=` in `execute()` only fires when `raw.status` is `undefined` or `null`.

---

### External tools that override `handleError` with `Status.InvalidTransaction`

Third-party tools that override `handleError` and return `status: Status.InvalidTransaction` will produce `errorCode: 'UNKNOWN'` rather than `'ERROR'`. After a JSON round-trip `Status.InvalidTransaction` deserialises as `{ _code: 1 }` (an object, not a string), so `classifyToolResult` cannot match it against any known status string and falls back to `'UNKNOWN'`. The core tools no longer do this, but external plugins may still be inconsistent.
**Who is affected:** Plugin authors who copied the previous `handleError` pattern from core tools.
**Fix:** Replace `status: Status.InvalidTransaction` with `status: TOOL_STATUS.ERROR` in `handleError`.

---

### Consumers checking `raw.status._code` on error

Code that inspects `raw.status._code` to detect or branch on transaction tool errors will no longer find a numeric code — `raw.status` is now the string `'ERROR'`. The error description is in `raw.error` (and `humanMessage`).
**Who is affected:** Any consumer that was reading `raw.status._code` directly from a tool error envelope.
**Fix:** Use `classifyToolResult` and switch on `kind`. For `kind: 'failure'`, `errorCode` holds the value.

---

### `transactionToolOutputParser` RETURN_BYTES output shape

`raw` in RETURN_BYTES mode now includes `status: 'SUCCESS'` alongside `bytes` (set by `BaseTool.execute()` via `??=`, since `ReturnBytesStrategy` already sets it). Code that checked for the exact set of keys (e.g. `Object.keys(raw).length === 1`) would see an additional field.
**Who is affected:** Unlikely in practice, but any consumer parsing the RETURN_BYTES raw envelope by exact structure.
**Fix:** Check for the presence of `raw.bytes` rather than the absence of other keys.

---

### `raw.error` no longer carries the `"Failed to execute <Tool>: "` prefix on receipt/precheck failures

On a `ReceiptStatusError` or `PrecheckStatusError` path, `raw.error` is now the bare SDK message (e.g. `"receipt for transaction 0.0.9414979@... contained error status INSUFFICIENT_PAYER_BALANCE"`). Consumers previously seeing the prefixed form in `raw.error` and doing a `startsWith("Failed to ")` check will miss.
**Who is affected:** Anything that parses or asserts on the exact contents of `raw.error` for transaction tools.
**Fix:** If you need the human-facing prefixed string, read `humanMessage`. If you need to detect the SDK status, read `raw.errorCode` or `classifyToolResult(...).errorCode`. `raw.error` is now intended as the machine-readable underlying message.

Generic (non-receipt/precheck) errors are unchanged: `raw.error === humanMessage === "Failed to execute <Tool>: <message>"`.

---

### `humanMessage` wording changed for transaction failures

Every transaction tool's failure `humanMessage` now begins with `"Failed to execute <Tool Name>: ..."`. Previously each tool used a bespoke phrase (`"Failed to dissociate"`, `"Failed to sign scheduled transaction"`, `"Failed to update token:"`, etc.).
**Who is affected:** Any consumer, log filter, or test that regex-matches on the old per-tool prose.
**Fix:** Match on the new template. The `<Tool Name>` segment is exactly the tool's `name` field — see each tool file for the canonical string. Where possible, prefer branching on `raw.errorCode` or `classifyToolResult(...).errorCode` instead of `humanMessage`, since structured fields are stable across wording changes.

---

### Transaction tools now extend `BaseTransactionTool`, not `BaseTool`

All 33 in-repo transaction tools were reparented from `BaseTool` to `BaseTransactionTool`. The class hierarchy is `BaseTransactionTool extends BaseTool`, so `instanceof BaseTool` checks still succeed. However, custom transaction tools authored by plugin developers should also migrate to preserve the structured error fields.
**Who is affected:** Plugin authors with custom transaction tools that extend `BaseTool` directly and want the `errorCode` / `transactionId` promotion behavior.
**Fix:** Change `extends BaseTool` to `extends BaseTransactionTool` and remove any local `handleError` override that only wrapped the receipt/precheck error in prose. `BaseTransactionTool` is exported from `@hashgraph/hedera-agent-kit`.


**Related issue(s)**:

Fixes #987

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)

