### PR TITLE
docs: standardize tool naming conventions in HOOKS_AND_POLICIES.md

### DIFF
--- a/docs/HOOKS_AND_POLICIES.md
+++ b/docs/HOOKS_AND_POLICIES.md
@@ -64,9 +64,9 @@ import { HcsAuditTrailHook, MaxRecipientsPolicy, RejectToolPolicy } from '@hashg
 
 const context = {
   hooks: [
-    new HcsAuditTrailHook(['transfer_hbar'], '0.0.12345'),
+    new HcsAuditTrailHook(['transfer_hbar_tool'], '0.0.12345'),
     new MaxRecipientsPolicy(5),
-    new RejectToolPolicy(['delete_account']),
+    new RejectToolPolicy(['delete_account_tool']),
   ],
   // ... other configuration
 };
@@ -102,7 +102,7 @@ Provides an immutable audit trail by logging tool executions to a Hedera Consens
 
 **Parameters**:
 
-- `relevantTools`: `string[]` - List of tools to audit (e.g., `['transfer_hbar', 'create_token']`).
+- `relevantTools`: `string[]` - List of tools to audit (e.g., `['transfer_hbar_tool', 'create_fungible_token_tool']`).
 - `hcsTopicId`: `string` - The pre-created Hedera topic ID (e.g., `'0.0.12345'`).
 - `loggingClient?`: `Client` - (Optional) A separate Hedera client for logging. If not provided, defaults to the agent's
   operator client. Must have submission access to the topic.
@@ -113,7 +113,7 @@ Provides an immutable audit trail by logging tool executions to a Hedera Consens
 import { HcsAuditTrailHook } from '@hashgraph/hedera-agent-kit/hooks';
 
 const auditHook = new HcsAuditTrailHook(
-  ['transfer_hbar', 'create_token'],
+  ['transfer_hbar_tool', 'create_fungible_token_tool'],
   '0.0.12345' // Ensure this topic exists and the agent can post to it
 );
 
@@ -164,7 +164,7 @@ INDEXED registry as the session topic to list audit entries.
 import { HolAuditTrailHook } from '@hashgraph/hedera-agent-kit/hooks';
 
 const holAuditHook = new HolAuditTrailHook({
-  relevantTools: ['transfer_hbar', 'create_token'],
+  relevantTools: ['transfer_hbar_tool', 'create_fungible_token_tool'],
   sessionId: '0.0.12345'
 });
 
@@ -195,12 +195,12 @@ exceed a defined threshold to prevent massive unauthorized transfers.
 **Default Supported Tools**:
 By default, the policy knows how to count recipients for:
 
-- `transfer_hbar`
-- `transfer_hbar_with_allowance`
-- `airdrop_fungible_token`
-- `transfer_fungible_token_with_allowance`
-- `transfer_non_fungible_token`
-- `transfer_non_fungible_token_with_allowance`
+- `transfer_hbar_tool`
+- `transfer_hbar_with_allowance_tool`
+- `airdrop_fungible_token_tool`
+- `transfer_fungible_token_with_allowance_tool`
+- `transfer_non_fungible_token_tool`
+- `transfer_non_fungible_token_with_allowance_tool`
 
 **Parameters**:
 
@@ -244,14 +244,14 @@ this policy ensures the agent cannot execute it under any circumstances.
 
 **Parameters**:
 
-- `relevantTools`: `string[]` - The list of tool methods to be blocked (e.g., `['delete_account', 'freeze_token']`).
+- `relevantTools`: `string[]` - The list of tool methods to be blocked (e.g., `['delete_account_tool', 'delete_topic_tool']`).
 
 **Example Usage**:
 
 ```typescript
 import { RejectToolPolicy } from '@hashgraph/hedera-agent-kit/policies';
 
-const safetyPolicy = new RejectToolPolicy(['delete_account']);
+const safetyPolicy = new RejectToolPolicy(['delete_account_tool']);
 
 const context = {
   hooks: [safetyPolicy],
@@ -423,8 +423,8 @@ public async postParamsNormalizationHook(
 ): Promise<any> {
   // Filter and branch based on the tool
   switch (method) {
-    case 'transfer_hbar':
-    case 'transfer_hbar_with_allowance': {
+    case 'transfer_hbar_tool':
+    case 'transfer_hbar_with_allowance_tool': {
       // Both tools share the normalised 'hbarTransfers' structure
       const p = params.normalisedParams as { hbarTransfers: Array<{ accountId: string; amount: Hbar }> };
 
@@ -435,7 +435,7 @@ public async postParamsNormalizationHook(
       console.log(`Total HBAR being transferred: ${total}`);
       break;
     }
-    case 'create_account': {
+    case 'create_account_tool': {
       const p = params.normalisedParams as { initialBalance: number };
       console.log(`Creating account with balance: ${p.initialBalance}`);
       break;
@@ -523,7 +523,7 @@ import {
 export class MyCustomHook extends AbstractHook {
   name = 'My Custom Hook';
   description = 'Detailed explanation of what this hook does';
-  relevantTools = ['create_account', 'transfer_hbar']; // List specific tools
+  relevantTools = ['create_account_tool', 'transfer_hbar_tool']; // List specific tools
 
   // Implement any of the 4 hook methods you need.
 
@@ -597,7 +597,7 @@ import { Hbar } from '@hiero-ledger/sdk';
 export class MyCustomPolicy extends AbstractPolicy {
   name = 'My Custom Policy';
   description = 'Detailed explanation of what this policy blocks';
-  relevantTools = ['transfer_hbar', 'transfer_fungible_token'];
+  relevantTools = ['transfer_hbar_tool', 'airdrop_fungible_token_tool'];
 
   // Implement at least one of the shouldBlock... methods for the policy to function
   // Return true to BLOCK execution, false to ALLOW

--- a/docs/MIGRATION-v4.md
+++ b/docs/MIGRATION-v4.md
@@ -566,7 +566,7 @@ Hooks and policies tap into stages 1, 3, 5, and 7 automatically — **you never 
 
 ### Step-by-step migration
 
-Below is a fully annotated before/after comparison using the `transfer_hbar` tool as the reference example.
+Below is a fully annotated before/after comparison using the `transfer_hbar_tool` tool as the reference example.
 
 #### Before (v3 — functional `Tool` object)
 

--- a/packages/core/src/hooks/hcs-audit-trail-hook.ts
+++ b/packages/core/src/hooks/hcs-audit-trail-hook.ts
@@ -31,7 +31,7 @@ export class HcsAuditTrailHook extends AbstractHook {
   loggingClient?: Client;
 
   /**
-   * @param relevantTools Tool names to audit (e.g. `['transfer_hbar', 'create_token']`).
+   * @param relevantTools Tool names to audit (e.g. `['transfer_hbar_tool', 'create_fungible_token_tool']`).
    * @param hcsTopicId Id of a **pre-existing** HCS topic to log to — the hook does not create it.
    * @param loggingClient Optional client used to submit audit messages; defaults to the agent's
    *   operator client. Must be allowed to submit to `hcsTopicId`.

--- a/packages/core/tests/unit/hooks/hol-audit-trail-hook/audit/audit-entry.unit.test.ts
+++ b/packages/core/tests/unit/hooks/hol-audit-trail-hook/audit/audit-entry.unit.test.ts
@@ -13,7 +13,7 @@ describe('buildAuditEntry', () => {
 
   it('should build a valid audit entry with all fields provided', () => {
     const entry = buildAuditEntry({
-      tool: 'transfer_hbar',
+      tool: 'transfer_hbar_tool',
       params: { amount: 100, to: '0.0.456' },
       result: {
         raw: { status: 'SUCCESS', transactionId: '0.0.1@123' },
@@ -24,7 +24,7 @@ describe('buildAuditEntry', () => {
     expect(entry.type).toBe(HOL_AUDIT_ENTRY_TYPE);
     expect(entry.version).toBe(HOL_AUDIT_ENTRY_VERSION);
     expect(entry.source).toBe(HOL_AUDIT_ENTRY_SOURCE);
-    expect(entry.tool).toBe('transfer_hbar');
+    expect(entry.tool).toBe('transfer_hbar_tool');
     expect(entry.params).toEqual({ amount: 100, to: '0.0.456' });
     expect(entry.result.raw).toEqual({ status: 'SUCCESS', transactionId: '0.0.1@123' });
     expect(entry.result.message).toBe('Transfer of 100 HBAR succeeded');
@@ -32,7 +32,7 @@ describe('buildAuditEntry', () => {
 
   it('should produce entries that pass auditEntrySchema Zod validation', () => {
     const entry = buildAuditEntry({
-      tool: 'create_token',
+      tool: 'create_fungible_token_tool',
       params: { name: 'Test Token' },
       result: {
         raw: { tokenId: '0.0.789' },

--- a/packages/core/tests/unit/hooks/hol-audit-trail-hook/audit/writers/hol-audit-writer.unit.test.ts
+++ b/packages/core/tests/unit/hooks/hol-audit-trail-hook/audit/writers/hol-audit-writer.unit.test.ts
@@ -26,7 +26,7 @@ const makeEntry = (): AuditEntry => ({
   version: '1.0',
   source: 'hedera-agent-kit-js',
   timestamp: new Date().toISOString(),
-  tool: 'transfer_hbar',
+  tool: 'transfer_hbar_tool',
   params: { amount: 100 },
   result: { raw: { status: 'SUCCESS' }, message: 'ok' },
 });


### PR DESCRIPTION
**Description**:

Resolves reported gap: 
```
Runtime tool names and documentation examples should be aligned.
 During audit/logging work, tool calls appeared with names such as 
 mint_non_fungible_token_tool while 
 some examples/docs refer to shorter names. A short note documenting runtime
  names would save debugging time for teams building compliance logs.
```

**Related issue(s)**:

Relate to #880

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
