### PR TITLE
docs: add multi-account signing pattern and improve framework-adapter discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,6 @@ The Hedera Agent Kit is an open-source toolkit that brings intelligent agent wor
 
 As of v4, the Hedera Agent Kit is organized as a monorepo of `@hashgraph`-scoped packages. You install the core package plus only the toolkit for your framework (LangChain, Vercel AI SDK, ElizaOS, or MCP). See the [v3 → v4 Migration Guide](docs/MIGRATION-v4.md) for details.
 
-| Framework | Package | Example |
-| --------- | ------- | ------- |
-| LangChain | [`@hashgraph/hedera-agent-kit-langchain`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-langchain) | [examples/langchain](examples/langchain), [examples/langchain-v1](examples/langchain-v1) |
-| Vercel AI SDK | [`@hashgraph/hedera-agent-kit-ai-sdk`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-ai-sdk) | [examples/ai-sdk](examples/ai-sdk) |
-| Model Context Protocol (MCP) | [`@hashgraph/hedera-agent-kit-mcp`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-mcp) | [examples/modelcontextprotocol](examples/modelcontextprotocol) |
-| ElizaOS | [`@hashgraph/hedera-agent-kit-elizaos`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-elizaos) | [ElizaOS guide](docs/DEVEXAMPLES.md#option-f-try-out-the-hedera-agent-kit-with-elizaos) |
-| Google ADK | [`@hashgraph/hedera-agent-kit-adk`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-adk) | [examples/adk](examples/adk) |
-
-> [!TIP]
-> Building with the Vercel AI SDK (`streamText`/`generateText`)? Use `@hashgraph/hedera-agent-kit-ai-sdk` — its `getTools()` returns natively typed AI SDK tools. Do not map LangChain tools to AI SDK tools by hand; it leads to `Type instantiation is excessively deep` build errors.
-
 The Hedera Agent Kit is extensible with third party plugins by other projects.
 
 ---

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ The Hedera Agent Kit is an open-source toolkit that brings intelligent agent wor
 
 As of v4, the Hedera Agent Kit is organized as a monorepo of `@hashgraph`-scoped packages. You install the core package plus only the toolkit for your framework (LangChain, Vercel AI SDK, ElizaOS, or MCP). See the [v3 → v4 Migration Guide](docs/MIGRATION-v4.md) for details.
 
+| Framework | Package | Example |
+| --------- | ------- | ------- |
+| LangChain | [`@hashgraph/hedera-agent-kit-langchain`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-langchain) | [examples/langchain](examples/langchain), [examples/langchain-v1](examples/langchain-v1) |
+| Vercel AI SDK | [`@hashgraph/hedera-agent-kit-ai-sdk`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-ai-sdk) | [examples/ai-sdk](examples/ai-sdk) |
+| Model Context Protocol (MCP) | [`@hashgraph/hedera-agent-kit-mcp`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-mcp) | [examples/modelcontextprotocol](examples/modelcontextprotocol) |
+| ElizaOS | [`@hashgraph/hedera-agent-kit-elizaos`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-elizaos) | [ElizaOS guide](docs/DEVEXAMPLES.md#option-f-try-out-the-hedera-agent-kit-with-elizaos) |
+| Google ADK | [`@hashgraph/hedera-agent-kit-adk`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-adk) | [examples/adk](examples/adk) |
+
+> [!TIP]
+> Building with the Vercel AI SDK (`streamText`/`generateText`)? Use `@hashgraph/hedera-agent-kit-ai-sdk` — its `getTools()` returns natively typed AI SDK tools. Do not map LangChain tools to AI SDK tools by hand; it leads to `Type instantiation is excessively deep` build errors.
+
 The Hedera Agent Kit is extensible with third party plugins by other projects.
 
 ---
@@ -80,7 +91,7 @@ The Hedera Agent Kit provides a flexible and powerful system for putting limits 
 
 For more information on hooks and policies, see the [Hooks and Policies documentation](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/HOOKS_AND_POLICIES.md).
 
-Try out an example [Audit Hook Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-i-try-out-the-audit-hook-agent) to see how hooks and policies work in practice.
+Try out an example [Audit Trail Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-i-run-the-audit-trail-agent) to see how hooks and policies work in practice.
 
 ---
 
@@ -92,12 +103,15 @@ You can try out examples of the different types of agents you can build by follo
 First follow instructions in the [Developer Examples to clone and configure the example](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md), then choose from one of the examples to run:
 
 - **Option A -** [Example Tool Calling Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-a-run-the-example-tool-calling-agent)
-- **Option B -** [Example Structured Chat Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-b-run-the-structured-chat-agent)
-- **Option C -** [Example Return Bytes Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-c-try-the-human-in-the-loop-chat-agent)
+- **Option B -** [Example Structured Chat Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-b-run-the-structured-chat-agent-langchain-v03-only)
+- **Option C -** [Example Human in the Loop Chat Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-c-try-the-human-in-the-loop-chat-agent)
 - **Option D -** [Example MCP Server](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-d-try-out-the-mcp-server)
-- **Option E -** [Example ElizaOS Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-e-try-out-the-hedera-agent-kit-with-elizaos)
-- **Option F -** [Example Preconfigured MCP Client Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-g-try-out-the-preconfigured-mcp-client-agent)
-- **Option G -** [Example Google ADK Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-h-try-out-the-google-adk-agent)
+- **Option E -** [Example External MCP Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-e-try-out-the-external-mcp-agent)
+- **Option F -** [Example ElizaOS Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-f-try-out-the-hedera-agent-kit-with-elizaos)
+- **Option G -** [Example Preconfigured MCP Client Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-g-try-out-the-preconfigured-mcp-client-agent)
+- **Option H -** [Example Policy Enforcement Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-h-run-the-policy-enforcement-agent)
+- **Option I -** [Example Audit Trail Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-i-run-the-audit-trail-agent)
+- **Option J -** [Example Google ADK Agent](https://github.com/hashgraph/hedera-agent-kit-js/blob/main/docs/DEVEXAMPLES.md#option-j-try-out-the-google-adk-agent)
 
 ---
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -380,6 +380,34 @@ Add your plugin to the main plugins index (src/plugins/index.ts):
 - Respect the AgentMode (`AUTONOMOUS` vs `RETURN_BYTES`)
 - Implement proper transaction building patterns
 
+**Multi-Account Signing**
+
+`handleTransaction()` signs with the operator of whichever `Client` you pass — the toolkit's client is just the default your tool receives. To sign from a different account than the agent's operator (e.g. a separate treasury or distributor wallet), build a dedicated client inside your tool and pass that one instead:
+
+```typescript
+import { Client, PrivateKey, TransferTransaction } from '@hiero-ledger/sdk';
+import { BaseTool, Context, handleTransaction } from '@hashgraph/hedera-agent-kit';
+
+export class TreasuryPayoutTool extends BaseTool {
+  // method, name, description, parameters, normalizeParams, coreAction:
+  // see the Step-by-Step Guide above. coreAction builds the TransferTransaction.
+
+  // A client whose operator is the treasury account — not the agent's operator.
+  // The account ID is a string, but the key must be a PrivateKey instance.
+  private treasuryClient = Client.forTestnet().setOperator(
+    process.env.TREASURY_ACCOUNT_ID!,
+    PrivateKey.fromStringECDSA(process.env.TREASURY_PRIVATE_KEY!), // or fromStringED25519 for an ED25519 key
+  );
+
+  async secondaryAction(tx: TransferTransaction, _client: Client, context: Context) {
+    // Sign and submit as the treasury account instead of the agent's operator
+    return handleTransaction(tx, this.treasuryClient, context);
+  }
+}
+```
+
+The `AgentMode` is still respected. In `RETURN_BYTES` mode nothing is signed server-side: `handleTransaction()` returns unsigned bytes for `context.accountId` (the connected user's account) regardless of which client you pass, so human-in-the-loop flows are unaffected. The signer swap above only changes behaviour in `AUTONOMOUS` mode.
+
 ### Tool Output Parsing
 
 The Hedera Agent Kit tools return a structured JSON output that needs to be parsed to be useful for the agent and the user.

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -2,6 +2,9 @@
 
 This is a [Next.js 15](https://nextjs.org/) template bootstrapped for the Hedera Agent Kit, supporting both **AUTONOMOUS** and **RETURN_BYTES (HITL)** execution modes.
 
+> [!NOTE]
+> This template uses the **LangChain adapter** (`@hashgraph/hedera-agent-kit-langchain`). If you are building with the **Vercel AI SDK** (`streamText`/`generateText`), use [`@hashgraph/hedera-agent-kit-ai-sdk`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-ai-sdk) instead — see [examples/ai-sdk](../ai-sdk). Mapping LangChain tools to AI SDK tools by hand leads to `Type instantiation is excessively deep` TypeScript errors.
+
 > [!IMPORTANT]
 > **Migrating from v3 to v4?** Check out our [Migration Guide](../../docs/MIGRATION-v4.md).
 > 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -3,7 +3,7 @@
 This is a [Next.js 15](https://nextjs.org/) template bootstrapped for the Hedera Agent Kit, supporting both **AUTONOMOUS** and **RETURN_BYTES (HITL)** execution modes.
 
 > [!NOTE]
-> This template uses the **LangChain adapter** (`@hashgraph/hedera-agent-kit-langchain`). If you are building with the **Vercel AI SDK** (`streamText`/`generateText`), use [`@hashgraph/hedera-agent-kit-ai-sdk`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-ai-sdk) instead — see [examples/ai-sdk](../ai-sdk). Mapping LangChain tools to AI SDK tools by hand leads to `Type instantiation is excessively deep` TypeScript errors.
+> This template uses the **LangChain adapter** (`@hashgraph/hedera-agent-kit-langchain`). If you are building with the **Vercel AI SDK** (`streamText`/`generateText`), use [`@hashgraph/hedera-agent-kit-ai-sdk`](https://www.npmjs.com/package/@hashgraph/hedera-agent-kit-ai-sdk) instead — see [examples/ai-sdk](../ai-sdk).
 
 > [!IMPORTANT]
 > **Migrating from v3 to v4?** Check out our [Migration Guide](../../docs/MIGRATION-v4.md).


### PR DESCRIPTION
**Description**:
  This PR collects two documentation improvements that came out of bounties build feedback: a documented multi-account signing pattern for custom plugin tools, and better discoverability of the framework adapters (plus fixes to stale example links). No runtime code changes.

  - Add a Multi-Account Signing section to docs/PLUGINS.md showing how to sign from a non-operator account (e.g. treasury/distributor) by passing a dedicated Client to handleTransaction, and clarifying that RETURN_BYTES mode is unaffected
  - Add a framework → package → example table and a Vercel AI SDK tip to README.md, steering AI SDK users to @hashgraph/hedera-agent-kit-ai-sdk instead of hand-mapping LangChain tools
  - Add a note to examples/nextjs/README.md pointing Vercel AI SDK users to the -ai-sdk adapter
  - Fix stale Developer Examples anchors in README.md (ElizaOS, ADK, Audit Trail) and align the option list with docs/DEVEXAMPLES.md

**Related issue(s)**:

Fixes #877 
Fixes #918