### PR TITLE
feat: add structured policy block responses and handling

### DIFF
--- a/docs/DEVEXAMPLES.md
+++ b/docs/DEVEXAMPLES.md
@@ -393,11 +393,26 @@ These agents connect to the configured MCP servers (defined in your code) and al
 
 ### Option H: Run the Policy Enforcement Agent
 
-This example demonstrates how to use the **MaxRecipientsPolicy** to enforce rules on transactions. In this case, it restricts any HBAR transfer to a maximum of 2 recipients.
+This example demonstrates **two ways to author a blocking policy** and how to read the
+structured result back in your code:
+
+- **Path 1 — `return true`**: An inline `MaintenanceModePolicy` (kill-switch) simply
+  returns `true` from `shouldBlockPreToolExecution`. `AbstractPolicy` automatically throws
+  a base `PolicyBlockedError` (policy name, stage — no custom details). Toggle
+  `enabled: true` in the source to activate.
+- **Path 2 — `throw PolicyBlockedError` with details**: The built-in `MaxRecipientsPolicy(2)`
+  throws with structured `details: { recipientCount, maxRecipients }` for programmatic
+  branching. Trigger it by asking the agent to send HBAR to more than 2 recipients at once.
+
+Each example also shows how to extract the structured policy-block data from tool results
+using the framework's parser (`PolicyResultParser` for AI SDK / ADK;
+`ResponseParserService` for LangChain), so you can branch on `policyName`, `stage`, and
+`details` rather than parsing prose.
 
 **Found at:**
 - `examples/ai-sdk/policy-enforcement-agent.ts`
 - `examples/langchain-v1/policy-enforcement-agent.ts`
+- `examples/adk/policy-enforcement-agent.ts`
 
 #### Running the Example
 
@@ -415,6 +430,14 @@ npm run ai-sdk:policy-enforcement-agent
 cd examples/langchain-v1
 npm install
 npm run langchain:policy-enforcement-agent
+```
+
+##### Google ADK
+
+```bash
+cd examples/adk
+npm install
+npm run adk:policy-enforcement-agent
 ```
 
 ---

--- a/docs/HOOKS_AND_POLICIES.md
+++ b/docs/HOOKS_AND_POLICIES.md
@@ -14,6 +14,7 @@ through **Hooks** and **Policies**.
 - [Quick Overview](#quick-overview)
 - [When Hooks and Policies are Called](#when-hooks-and-policies-are-called)
 - [How to Use Hooks and Policies](#how-to-use-hooks-and-policies)
+- [Blocking with Policies](#blocking-with-policies)
 - [Available Hooks](#available-hooks)
     - [HcsAuditTrailHook](#1-hcsaudittrailhook-hook)
     - [HolAuditTrailHook](#2-holaudittrailhook-hook)
@@ -79,6 +80,185 @@ const context = {
 > [!TIP]
 > **Example Application**: See [Option I: Run the Audit Trail Agent](DEVEXAMPLES.md#option-i-run-the-audit-trail-agent)
 > in the Developer Examples for a complete working implementation across different frameworks.
+
+---
+
+## Blocking with Policies
+
+When a policy fires, the tool call is **immediately halted** and a `PolicyBlockedError` is surfaced to the agent.
+The error carries structured data through the `{ raw, humanMessage }` envelope so you can
+**branch on machine-readable fields** in your own code instead of pattern-matching prose.
+
+### Two ways to author a policy block
+
+#### Path 1 — return `true` (base block, no custom details)
+
+Return `true` from a `shouldBlock*` guard. `AbstractPolicy` automatically throws a base
+`PolicyBlockedError` that carries the policy name, description, blocked tool method, and
+hook stage — but no custom `details` payload.
+
+```typescript
+import { AbstractPolicy } from '@hashgraph/hedera-agent-kit';
+import { coreAccountPluginToolNames } from '@hashgraph/hedera-agent-kit/plugins';
+
+class MaintenanceModePolicy extends AbstractPolicy {
+  readonly name = 'Maintenance Mode Policy';
+  readonly description = 'Transfers are temporarily disabled for maintenance';
+  readonly relevantTools = [coreAccountPluginToolNames.TRANSFER_HBAR_TOOL];
+
+  constructor(private readonly enabled: boolean) { super(); }
+
+  // Returning `true` is all you need — AbstractPolicy throws the error for you.
+  protected shouldBlockPreToolExecution(): boolean {
+    return this.enabled;
+  }
+}
+```
+
+#### Path 2 — throw `PolicyBlockedError` directly (structured details)
+
+Throw a `PolicyBlockedError` yourself from a `shouldBlock*` method when you want to
+attach a machine-readable `details` payload for programmatic branching. The built-in
+`MaxRecipientsPolicy` uses this path:
+
+```typescript
+import {
+  AbstractPolicy,
+  PolicyBlockedError,
+  POLICY_BLOCK_STAGES,
+} from '@hashgraph/hedera-agent-kit';
+
+class MaxRecipientsPolicy extends AbstractPolicy {
+  // ...
+  protected shouldBlockPostParamsNormalization(params, method) {
+    const recipientCount = this.countRecipients(params.normalisedParams, method);
+    if (recipientCount > this.maxRecipients) {
+      throw new PolicyBlockedError(
+        this.name,
+        method,
+        POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION,
+        this.description,
+        { recipientCount, maxRecipients: this.maxRecipients }, // <- structured details
+      );
+    }
+    return false;
+  }
+}
+```
+
+Both paths produce the same `{ raw, humanMessage }` envelope shape — only the presence of
+`details` differs.
+
+### The result envelope shape
+
+When a policy fires, the tool returns:
+
+| Field | Value |
+|---|---|
+| `humanMessage` | Prose error for the LLM: `"Action transfer_hbar_tool blocked by policy: Max Recipients Policy (…)"` |
+| `raw.status` | `'ERROR'` |
+| `raw.errorCode` | `'POLICY_BLOCKED'` |
+| `raw.error` | Same prose as `humanMessage` |
+| `raw.policyBlock.code` | `'POLICY_BLOCKED'` (stable discriminant) |
+| `raw.policyBlock.policyName` | Display name of the policy that fired |
+| `raw.policyBlock.toolMethod` | The blocked tool method string |
+| `raw.policyBlock.stage` | Hook stage: `pre_tool_execution` \| `post_params_normalization` \| `post_core_action` \| `post_secondary_action` |
+| `raw.policyBlock.description` | Optional: the policy's description string |
+| `raw.policyBlock.details` | Optional: structured payload from Path 2 (e.g. `{ recipientCount: 3, maxRecipients: 2 }`) |
+
+> [!NOTE]
+> `humanMessage` is the prose the LLM sees and explains to the user. `raw.policyBlock` is
+> for your server-side code to branch on. Never parse `humanMessage` with substring
+> matching — use `raw.policyBlock` instead.
+
+### Reading policy blocks in your code
+
+#### Core utilities (framework-agnostic)
+
+```typescript
+import {
+  classifyToolResult,
+  isPolicyBlockedToolResult,
+} from '@hashgraph/hedera-agent-kit';
+
+const result = await tool.execute(client, context, params);
+
+// Quick boolean check
+if (isPolicyBlockedToolResult(result)) {
+  console.log(result.raw.policyBlock.policyName);
+}
+
+// Full discriminated union — type-safe branching
+const classified = classifyToolResult(result);
+if (classified.kind === 'policy_block') {
+  console.log(classified.policyName);  // string
+  console.log(classified.stage);       // PolicyBlockStage
+  console.log(classified.details);     // Record<string, unknown> | undefined
+}
+```
+
+#### AI SDK (`PolicyResultParser`)
+
+```typescript
+import { PolicyResultParser } from '@hashgraph/hedera-agent-kit-ai-sdk';
+
+const parser = new PolicyResultParser();
+
+// After generateText / streamText:
+const allToolResults = response.steps.flatMap((step) => step.toolResults ?? []);
+const policyBlocks = parser.parsePolicyBlocks(allToolResults);
+
+for (const block of policyBlocks) {
+  console.log(block.policyName, block.stage, block.details);
+}
+```
+
+#### ADK (`PolicyResultParser` from the ADK package)
+
+```typescript
+import { PolicyResultParser } from '@hashgraph/hedera-agent-kit-adk';
+import { getFunctionResponses, isFinalResponse } from '@google/adk';
+
+const parser = new PolicyResultParser();
+const turnToolResults: any[] = [];
+
+for await (const event of runner.runAsync({ ... })) {
+  for (const fr of getFunctionResponses(event)) {
+    if (fr.response) turnToolResults.push(fr.response);
+  }
+  if (isFinalResponse(event)) {
+    const policyBlocks = parser.parsePolicyBlocks(turnToolResults);
+    for (const block of policyBlocks) {
+      console.log(block.policyName, block.stage, block.details);
+    }
+  }
+}
+```
+
+#### LangChain (`ResponseParserService`)
+
+```typescript
+import { ResponseParserService } from '@hashgraph/hedera-agent-kit-langchain';
+
+const responseParsingService = new ResponseParserService(toolkit.getTools());
+
+const response = await agent.invoke({ input: userMessage });
+if (responseParsingService.hasPolicyBlocks(response)) {
+  const policyBlocks = responseParsingService.parsePolicyBlocks(response);
+  for (const block of policyBlocks) {
+    console.log(block.policyName, block.stage, block.details);
+  }
+}
+```
+
+> [!TIP]
+> See the **Policy Enforcement Agent** examples for complete, runnable demonstrations of
+> both paths and parser usage across all three adapters:
+> [`examples/ai-sdk/policy-enforcement-agent.ts`](../examples/ai-sdk/policy-enforcement-agent.ts),
+> [`examples/langchain-v1/policy-enforcement-agent.ts`](../examples/langchain-v1/policy-enforcement-agent.ts),
+> [`examples/adk/policy-enforcement-agent.ts`](../examples/adk/policy-enforcement-agent.ts).
+
+---
 
 ## Available Hooks
 
@@ -252,8 +432,9 @@ const extendedPolicy = new MaxRecipientsPolicy(
 
 > [!NOTE]
 > **Complete Examples**: Check the [Policy Enforcement Agent](DEVEXAMPLES.md#option-h-run-the-policy-enforcement-agent)
-> for full implementations in [AI SDK](../examples/ai-sdk/policy-enforcement-agent.ts)
-> or [LangChain v1](../examples/langchain-v1/policy-enforcement-agent.ts).
+> for full implementations in [AI SDK](../examples/ai-sdk/policy-enforcement-agent.ts),
+> [LangChain v1](../examples/langchain-v1/policy-enforcement-agent.ts),
+> or [ADK](../examples/adk/policy-enforcement-agent.ts).
 
 ---
 
@@ -352,8 +533,11 @@ They should not stop execution unless an error occurs.
 ### Policies (`AbstractPolicy`)
 
 Policies are specialized Hooks designed to **validate** and **block** execution. They use `shouldBlock...` methods that
-return boolean values. If `true` is returned, the `AbstractPolicy` base class throws an error, immediately halting the tool's
-lifecycle.
+return boolean values. If `true` is returned, the `AbstractPolicy` base class throws a **`PolicyBlockedError`**,
+immediately halting the tool's lifecycle. Custom policies that need machine-readable structured data can instead
+`throw new PolicyBlockedError(policyName, method, stage, description, details)` directly from the `shouldBlock*` method
+to attach a `details` payload for programmatic branching — see the
+[Blocking with Policies](#blocking-with-policies) section above.
 
 **Policy Execution Flow:**
 
@@ -364,7 +548,7 @@ lifecycle.
          |
     [AbstractPolicy.preToolExecutionHook] (calls shouldBlockPreToolExecution)
          |
-    [shouldBlockPreToolExecution?] -- Yes --> [THROW ERROR] --> (Error returned to LLM/Agent)
+    [shouldBlockPreToolExecution?] -- Yes --> [THROW PolicyBlockedError] --> (raw.errorCode='POLICY_BLOCKED' / raw.policyBlock returned to LLM/Agent)
          |
          No
          |
@@ -687,8 +871,11 @@ export class MyCustomPolicy extends AbstractPolicy {
 **Best Practices:**
 
 1. **Naming**: Use descriptive names ending in `Policy`
-2. **Error Messages**: The `AbstractPolicy` base class will create error messages. For custom messages, you can throw your own
-   error in the `shouldBlock...` method
+2. **Error Messages / Structured Details**: The `AbstractPolicy` base class automatically creates a `PolicyBlockedError`
+   with a prose message when `true` is returned. To attach machine-readable `details` for programmatic branching (e.g.
+   `{ recipientCount, maxRecipients }`), `throw new PolicyBlockedError(name, method, stage, description, details)` directly
+   from the `shouldBlock*` method instead of returning `true`. The built-in `MaxRecipientsPolicy` demonstrates this pattern.
+   See [Blocking with Policies](#blocking-with-policies) for the full result envelope shape and how to read it back
 3. **Specificity**: Be specific about what conditions trigger blocking
 4. **Documentation**: Clearly document what conditions will block execution
 5. **Performance**: Keep validation logic fast

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -550,6 +550,14 @@ switch (result.kind) {
   case 'failure':
     // result.errorCode is the SDK status (e.g. 'INSUFFICIENT_PAYER_BALANCE') or 'ERROR'
     throw new Error(`tool failed (${result.errorCode}): ${result.error}`);
+  case 'policy_block':
+    // Tool was blocked by a policy. Typed fields for programmatic branching:
+    // result.policyName   — display name of the policy that fired
+    // result.stage        — hook stage ('pre_tool_execution' | 'post_params_normalization' | ...)
+    // result.details      — optional structured payload (e.g. { recipientCount, maxRecipients })
+    // result.humanMessage — prose explanation the LLM already received
+    console.warn(`[${result.policyName}] blocked at ${result.stage}`, result.details);
+    break;
   case 'parse_error':
     throw new Error(`tool output unparseable: ${result.humanMessage}`);
   case 'unknown':
@@ -560,6 +568,12 @@ switch (result.kind) {
 `ToolResultStatus<T>` (the return type) and `ToolRawStatus` (the `raw.status` string union) are
 also exported for annotating your own code. `classifyToolResult` is additive and opt-in — the
 parsers still return `{ raw, humanMessage }` unchanged.
+
+The `policy_block` kind surfaces whenever a policy blocked the tool via `raw.errorCode === 'POLICY_BLOCKED'`. It carries
+structured fields (`policyName`, `stage`, `details`) from the `PolicyBlockedError` thrown by the policy, making it safe
+to branch on without parsing prose. See [Blocking with Policies](HOOKS_AND_POLICIES.md#blocking-with-policies) for the
+full envelope shape, the two authoring paths, and per-adapter parsers (`PolicyResultParser` for AI SDK / ADK;
+`ResponseParserService` for LangChain).
 
 **RETURN_BYTES results are typed too.** In `RETURN_BYTES` mode a transaction tool's `raw` is a
 `ReturnBytesResult` (also exported from `@hashgraph/hedera-agent-kit`): `{ bytes, status,

--- a/examples/adk/package.json
+++ b/examples/adk/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "test": "echo \"No tests specified for example package\"",
     "adk:plugin-tool-calling-agent": "ts-node plugin-tool-calling-agent.ts",
+    "adk:policy-enforcement-agent": "ts-node policy-enforcement-agent.ts",
     "adk:return-bytes-agent": "ts-node return-bytes-agent.ts"
   },
   "dependencies": {

--- a/examples/adk/plugin-tool-calling-agent.ts
+++ b/examples/adk/plugin-tool-calling-agent.ts
@@ -55,7 +55,7 @@ async function bootstrap(): Promise<void> {
     model: 'gemini-3.1-flash-lite-preview',
     instruction:
       'You are a helpful assistant with access to Hedera blockchain tools. You can help users create accounts, transfer HBAR, manage tokens, create topics, and query blockchain information. Always provide clear explanations of the transactions you perform.',
-    tools: hederaAgentToolkit.getTools(),
+    tools: hederaAgentToolkit.getTools() as any,
   });
 
   // Setup session and runner

--- a/examples/adk/policy-enforcement-agent.ts
+++ b/examples/adk/policy-enforcement-agent.ts
@@ -1,0 +1,227 @@
+import { HederaADKToolkit, PolicyResultParser } from '@hashgraph/hedera-agent-kit-adk';
+import { AgentMode, AbstractPolicy } from '@hashgraph/hedera-agent-kit';
+import { MaxRecipientsPolicy } from '@hashgraph/hedera-agent-kit/policies';
+import {
+  coreAccountPlugin,
+  coreTokenPlugin,
+  coreAccountPluginToolNames,
+} from '@hashgraph/hedera-agent-kit/plugins';
+import { Client, PrivateKey } from '@hiero-ledger/sdk';
+import prompts from 'prompts';
+import * as dotenv from 'dotenv';
+import {
+  LlmAgent,
+  Runner,
+  InMemorySessionService,
+  isFinalResponse,
+  getFunctionResponses,
+} from '@google/adk';
+import { Content, Part } from '@google/genai';
+
+dotenv.config();
+
+// ---------------------------------------------------------------------------
+// Path 1 — simple boolean block (return true)
+//
+// Returning `true` from a `shouldBlock*` guard is the simplest way to block
+// a tool call. AbstractPolicy automatically throws a base PolicyBlockedError
+// carrying the policy name, description, blocked tool method, and hook stage
+// — but no custom `details` payload.
+//
+// Set `enabled: true` to activate this policy and observe the base block.
+// ---------------------------------------------------------------------------
+class MaintenanceModePolicy extends AbstractPolicy {
+  readonly name = 'Maintenance Mode Policy';
+  readonly description = 'Transfers are temporarily disabled for maintenance';
+  // Only applies to HBAR transfers; extend relevantTools to cover more methods.
+  readonly relevantTools = [coreAccountPluginToolNames.TRANSFER_HBAR_TOOL];
+
+  constructor(private readonly enabled: boolean) {
+    super();
+  }
+
+  // Path 1: returning `true` causes AbstractPolicy to throw a base
+  // PolicyBlockedError automatically — no custom details attached.
+  protected shouldBlockPreToolExecution(): boolean {
+    return this.enabled;
+  }
+}
+
+const APP_NAME = 'hedera_policy_agent_app';
+const USER_ID = 'hedera_user';
+const SESSION_ID = 'policy_session_1';
+
+async function bootstrap(): Promise<void> {
+  // Hedera client setup (Testnet by default)
+  const client = Client.forTestnet().setOperator(
+    process.env.ACCOUNT_ID!,
+    PrivateKey.fromStringECDSA(process.env.PRIVATE_KEY!),
+    // PrivateKey.fromStringED25519(process.env.PRIVATE_KEY!), // Use this line if you have an ED25519 key
+  );
+
+  // Path 1 — MaintenanceModePolicy (return true, no structured details).
+  // Toggle `enabled` to `true` to see this path block transfers immediately.
+  const maintenancePolicy = new MaintenanceModePolicy(false);
+
+  // Path 2 — MaxRecipientsPolicy (throws PolicyBlockedError with structured details).
+  // This policy throws with `details: { recipientCount, maxRecipients }` when the
+  // number of recipients in a transfer exceeds the configured cap.
+  // Trigger it by asking the agent to send HBAR to more than 2 recipients at once.
+  const maxRecipientsPolicy = new MaxRecipientsPolicy(2);
+
+  // Prepare Hedera toolkit with policy enforcement
+  const hederaAgentToolkit = new HederaADKToolkit({
+    client,
+    configuration: {
+      plugins: [coreAccountPlugin, coreTokenPlugin],
+      tools: [], // Load all tools from selected plugins
+      context: {
+        mode: AgentMode.AUTONOMOUS,
+        accountId: process.env.ACCOUNT_ID,
+        hooks: [maintenancePolicy, maxRecipientsPolicy],
+      },
+    },
+  });
+
+  // Parser for extracting structured policy-block data from ADK tool results.
+  const parser = new PolicyResultParser();
+
+  const agent = new LlmAgent({
+    name: 'hedera_policy_agent',
+    description:
+      'An AI agent that can interact with the Hedera blockchain network with policy enforcement.',
+    model: 'gemini-3.1-flash-lite-preview',
+    instruction:
+      'You are a helpful assistant with access to Hedera blockchain tools. ' +
+      'You can help users transfer HBAR and manage tokens. ' +
+      'DO NOT split transactions that are to multiple recipients into separate transactions.',
+    tools: hederaAgentToolkit.getTools(),
+  });
+
+  // Setup session and runner
+  const sessionService = new InMemorySessionService();
+  await sessionService.createSession({
+    appName: APP_NAME,
+    sessionId: SESSION_ID,
+    userId: USER_ID,
+  });
+
+  const runner = new Runner({
+    appName: APP_NAME,
+    agent,
+    sessionService,
+  });
+
+  console.log('='.repeat(60));
+  console.log('Hedera Agent CLI Chatbot with Policy Enforcement (ADK)');
+  console.log('='.repeat(60));
+  console.log("Type 'exit' or 'quit' to end the session.\n");
+  console.log('Two policies are configured:');
+  console.log(
+    '  [Path 1] MaintenanceModePolicy — simple return-true block, no structured details.',
+    'Set `enabled: true` in the source to activate.',
+  );
+  console.log(
+    '  [Path 2] MaxRecipientsPolicy   — throws PolicyBlockedError with details.',
+    'Ask the agent to send HBAR to >2 recipients at once to trigger it.',
+  );
+  console.log('');
+  console.log(
+    'When a policy blocks a tool the agent explains it in prose (humanMessage).',
+    'The === Policy Block === section shows the structured data your code can branch on.',
+  );
+  console.log('');
+
+  while (true) {
+    try {
+      const { userInput } = await prompts({
+        type: 'text',
+        name: 'userInput',
+        message: 'You:',
+      });
+
+      // Handle early termination
+      if (!userInput || ['exit', 'quit'].includes(userInput.trim().toLowerCase())) {
+        console.log('Goodbye!');
+        break;
+      }
+
+      // Create user message content
+      const newMessage: Content = {
+        role: 'user',
+        parts: [{ text: userInput } as Part],
+      };
+
+      // Run the agent via the Runner
+      const events = runner.runAsync({
+        userId: USER_ID,
+        sessionId: SESSION_ID,
+        newMessage,
+      });
+
+      // Collect tool results from function-response events during this turn.
+      // ADK's FunctionTool.execute returns { raw, humanMessage } which ADK exposes
+      // as FunctionResponse.response. getFunctionResponses() extracts these from
+      // each event so we can classify them with PolicyResultParser after the turn.
+      const turnToolResults: any[] = [];
+
+      // Process events and print the final response
+      for await (const event of events) {
+        // Accumulate tool results from this event (if any)
+        for (const fr of getFunctionResponses(event)) {
+          if (fr.response) turnToolResults.push(fr.response);
+        }
+
+        if (isFinalResponse(event)) {
+          // Print the AI's answer (prose message — what the LLM sees)
+          const textParts: string[] = [];
+          if (event.content?.parts) {
+            for (const part of event.content.parts) {
+              if ((part as any).functionCall) continue; // skip function calls
+              if (part.text) textParts.push(part.text);
+            }
+          }
+          if (textParts.length > 0) {
+            console.log(`AI: ${textParts.join(' ')}`);
+          }
+
+          // -----------------------------------------------------------------------
+          // Parser usage: extract structured policy-block data from tool results.
+          //
+          // parsePolicyBlocks() filters to only the `kind: 'policy_block'` entries,
+          // giving you typed fields for programmatic branching without substring-
+          // matching the prose message.
+          // -----------------------------------------------------------------------
+          const policyBlocks = parser.parsePolicyBlocks(turnToolResults);
+          if (policyBlocks.length > 0) {
+            console.log('\n=== Policy Block(s) Detected ===');
+            for (const block of policyBlocks) {
+              console.log(`  Policy  : ${block.policyName}`);
+              console.log(`  Stage   : ${block.stage}`);
+              if (block.description) console.log(`  Reason  : ${block.description}`);
+              if (block.details) console.log(`  Details : ${JSON.stringify(block.details)}`);
+              console.log(`  Message : ${block.humanMessage}`);
+              console.log('');
+              // Example of programmatic branching on structured fields:
+              // switch (block.policyName) {
+              //   case 'Maintenance Mode Policy': await notifyOps(block); break;
+              //   case 'Max Recipients Policy':   await queueForReview(block.details); break;
+              // }
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.error('Error:', err);
+    }
+  }
+}
+
+bootstrap()
+  .catch(err => {
+    console.error('Fatal error during CLI bootstrap:', err);
+    process.exit(1);
+  })
+  .then(() => {
+    process.exit(0);
+  });

--- a/examples/ai-sdk/policy-enforcement-agent.ts
+++ b/examples/ai-sdk/policy-enforcement-agent.ts
@@ -1,7 +1,7 @@
-import { AgentMode } from '@hashgraph/hedera-agent-kit';
-import { HederaAIToolkit } from '@hashgraph/hedera-agent-kit-ai-sdk';
+import { AgentMode, AbstractPolicy } from '@hashgraph/hedera-agent-kit';
+import { HederaAIToolkit, PolicyResultParser } from '@hashgraph/hedera-agent-kit-ai-sdk';
 import { MaxRecipientsPolicy } from '@hashgraph/hedera-agent-kit/policies';
-import { coreAccountPlugin } from '@hashgraph/hedera-agent-kit/plugins';
+import { coreAccountPlugin, coreAccountPluginToolNames } from '@hashgraph/hedera-agent-kit/plugins';
 import { Client, PrivateKey } from '@hiero-ledger/sdk';
 import prompts from 'prompts';
 import * as dotenv from 'dotenv';
@@ -9,6 +9,33 @@ import { openai } from '@ai-sdk/openai';
 import { generateText, stepCountIs, wrapLanguageModel } from 'ai';
 
 dotenv.config();
+
+// ---------------------------------------------------------------------------
+// Path 1 — simple boolean block (return true)
+//
+// Returning `true` from a `shouldBlock*` guard is the simplest way to block
+// a tool call. AbstractPolicy automatically throws a base PolicyBlockedError
+// carrying the policy name, description, blocked tool method, and hook stage
+// — but no custom `details` payload.
+//
+// Set `enabled: true` to activate this policy and observe the base block.
+// ---------------------------------------------------------------------------
+class MaintenanceModePolicy extends AbstractPolicy {
+  readonly name = 'Maintenance Mode Policy';
+  readonly description = 'Transfers are temporarily disabled for maintenance';
+  // Only applies to HBAR transfers; extend relevantTools to cover more methods.
+  readonly relevantTools = [coreAccountPluginToolNames.TRANSFER_HBAR_TOOL];
+
+  constructor(private readonly enabled: boolean) {
+    super();
+  }
+
+  // Path 1: returning `true` causes AbstractPolicy to throw a base
+  // PolicyBlockedError automatically — no custom details attached.
+  protected shouldBlockPreToolExecution(): boolean {
+    return this.enabled;
+  }
+}
 
 async function bootstrap(): Promise<void> {
   const operatorId = process.env.ACCOUNT_ID!;
@@ -20,8 +47,15 @@ async function bootstrap(): Promise<void> {
     // PrivateKey.fromStringED25519(operatorKey), // Use this line if you have an ED25519 key
   );
 
-  // Instantiate the MaxRecipientsPolicy, restricting transfers to a maximum of 2 recipients
-  const policy = new MaxRecipientsPolicy(2);
+  // Path 1 — MaintenanceModePolicy (return true, no structured details).
+  // Toggle `enabled` to `true` to see this path block transfers immediately.
+  const maintenancePolicy = new MaintenanceModePolicy(false);
+
+  // Path 2 — MaxRecipientsPolicy (throws PolicyBlockedError with structured details).
+  // This policy throws with `details: { recipientCount, maxRecipients }` when the
+  // number of recipients in a transfer exceeds the configured cap.
+  // Trigger it by asking the agent to send HBAR to more than 2 recipients at once.
+  const maxRecipientsPolicy = new MaxRecipientsPolicy(2);
 
   const hederaAgentToolkit = new HederaAIToolkit({
     client,
@@ -31,7 +65,7 @@ async function bootstrap(): Promise<void> {
       context: {
         mode: AgentMode.AUTONOMOUS,
         accountId: operatorId,
-        hooks: [policy],
+        hooks: [maintenancePolicy, maxRecipientsPolicy],
       },
     },
   });
@@ -41,9 +75,25 @@ async function bootstrap(): Promise<void> {
     middleware: hederaAgentToolkit.middleware(),
   });
 
+  // Parser for extracting structured policy-block data from AI SDK tool results.
+  const parser = new PolicyResultParser();
+
   console.log('Hedera Agent CLI Chatbot with Policy Enforcement — type "exit" to quit');
-  console.log('This agent explicitly loads tools related to Transfers and Airdrops.');
-  console.log('MaxRecipientsPolicy is ACTIVE: All transfers to >2 recipients are blocked.');
+  console.log('');
+  console.log('Two policies are configured:');
+  console.log(
+    '  [Path 1] MaintenanceModePolicy — simple return-true block, no structured details.',
+    'Set `enabled: true` in the source to activate.',
+  );
+  console.log(
+    '  [Path 2] MaxRecipientsPolicy   — throws PolicyBlockedError with details.',
+    'Ask the agent to send HBAR to >2 recipients at once to trigger it.',
+  );
+  console.log('');
+  console.log(
+    'When a policy blocks a tool the agent explains it in prose (humanMessage).',
+    'The === Policy Block === section shows the structured data your code can branch on.',
+  );
   console.log('');
 
   // Chat memory: conversation history
@@ -75,8 +125,39 @@ async function bootstrap(): Promise<void> {
       // Add AI response to history
       conversationHistory.push({ role: 'assistant', content: response.text });
 
-      // Print the AI's answer
+      // Print the AI's answer (prose message — what the LLM sees)
       console.log(`AI: ${response.text}`);
+
+      // -----------------------------------------------------------------------
+      // Parser usage: extract structured policy-block data from tool results.
+      //
+      // response.steps contains one entry per LLM round-trip; each step has a
+      // toolResults array whose entries have an `output` field with the
+      // { raw, humanMessage } envelope returned by the Hedera tool.
+      //
+      // parsePolicyBlocks() filters to only the `kind: 'policy_block'` entries,
+      // giving you typed fields for programmatic branching without substring-
+      // matching the prose message.
+      // -----------------------------------------------------------------------
+      const allToolResults = response.steps.flatMap((step) => step.toolResults ?? []);
+      const policyBlocks = parser.parsePolicyBlocks(allToolResults);
+
+      if (policyBlocks.length > 0) {
+        console.log('\n=== Policy Block(s) Detected ===');
+        for (const block of policyBlocks) {
+          console.log(`  Policy  : ${block.policyName}`);
+          console.log(`  Stage   : ${block.stage}`);
+          if (block.description) console.log(`  Reason  : ${block.description}`);
+          if (block.details) console.log(`  Details : ${JSON.stringify(block.details)}`);
+          console.log(`  Message : ${block.humanMessage}`);
+          console.log('');
+          // Example of programmatic branching on structured fields:
+          // switch (block.policyName) {
+          //   case 'Maintenance Mode Policy': await notifyOps(block); break;
+          //   case 'Max Recipients Policy':   await queueForReview(block.details); break;
+          // }
+        }
+      }
     } catch (err) {
       console.error('Error:', err);
     }

--- a/examples/langchain-v1/policy-enforcement-agent.ts
+++ b/examples/langchain-v1/policy-enforcement-agent.ts
@@ -1,9 +1,13 @@
-import { AgentMode } from '@hashgraph/hedera-agent-kit';
+import { AgentMode, AbstractPolicy } from '@hashgraph/hedera-agent-kit';
 import {
   HederaLangchainToolkit,
   ResponseParserService,
 } from '@hashgraph/hedera-agent-kit-langchain';
-import { coreAccountPlugin, coreTokenPlugin } from '@hashgraph/hedera-agent-kit/plugins';
+import {
+  coreAccountPlugin,
+  coreTokenPlugin,
+  coreAccountPluginToolNames,
+} from '@hashgraph/hedera-agent-kit/plugins';
 import { MaxRecipientsPolicy } from '@hashgraph/hedera-agent-kit/policies';
 
 import { Client, PrivateKey } from '@hiero-ledger/sdk';
@@ -14,6 +18,33 @@ import { MemorySaver } from '@langchain/langgraph';
 import { ChatOpenAI } from '@langchain/openai';
 
 dotenv.config();
+
+// ---------------------------------------------------------------------------
+// Path 1 — simple boolean block (return true)
+//
+// Returning `true` from a `shouldBlock*` guard is the simplest way to block
+// a tool call. AbstractPolicy automatically throws a base PolicyBlockedError
+// carrying the policy name, description, blocked tool method, and hook stage
+// — but no custom `details` payload.
+//
+// Set `enabled: true` to activate this policy and observe the base block.
+// ---------------------------------------------------------------------------
+class MaintenanceModePolicy extends AbstractPolicy {
+  readonly name = 'Maintenance Mode Policy';
+  readonly description = 'Transfers are temporarily disabled for maintenance';
+  // Only applies to HBAR transfers; extend relevantTools to cover more methods.
+  readonly relevantTools = [coreAccountPluginToolNames.TRANSFER_HBAR_TOOL];
+
+  constructor(private readonly enabled: boolean) {
+    super();
+  }
+
+  // Path 1: returning `true` causes AbstractPolicy to throw a base
+  // PolicyBlockedError automatically — no custom details attached.
+  protected shouldBlockPreToolExecution(): boolean {
+    return this.enabled;
+  }
+}
 
 async function bootstrap(): Promise<void> {
   // Hedera client setup (Testnet by default)
@@ -26,8 +57,15 @@ async function bootstrap(): Promise<void> {
     // PrivateKey.fromStringED25519(operatorKey), // Use this line if you have an ED25519 key
   );
 
-  // Instantiate the MaxRecipientsPolicy, restricting transfers to a maximum of 2 recipients
-  const policy = new MaxRecipientsPolicy(2);
+  // Path 1 — MaintenanceModePolicy (return true, no structured details).
+  // Toggle `enabled` to `true` to see this path block transfers immediately.
+  const maintenancePolicy = new MaintenanceModePolicy(false);
+
+  // Path 2 — MaxRecipientsPolicy (throws PolicyBlockedError with structured details).
+  // This policy throws with `details: { recipientCount, maxRecipients }` when the
+  // number of recipients in a transfer exceeds the configured cap.
+  // Trigger it by asking the agent to send HBAR to more than 2 recipients at once.
+  const maxRecipientsPolicy = new MaxRecipientsPolicy(2);
 
   // Prepare Hedera toolkit with policy enforcement
   const hederaAgentToolkit = new HederaLangchainToolkit({
@@ -38,7 +76,7 @@ async function bootstrap(): Promise<void> {
       context: {
         mode: AgentMode.AUTONOMOUS,
         accountId: operatorId,
-        hooks: [policy],
+        hooks: [maintenancePolicy, maxRecipientsPolicy],
       },
     },
   });
@@ -62,8 +100,21 @@ async function bootstrap(): Promise<void> {
   const responseParsingService = new ResponseParserService(tools);
 
   console.log('Hedera Agent CLI Chatbot with Policy Enforcement — type "exit" to quit');
-  console.log('This agent explicitly loads tools related to Transfers and Airdrops.');
-  console.log('MaxRecipientsPolicy is ACTIVE: All transfers to >2 recipients are blocked.');
+  console.log('');
+  console.log('Two policies are configured:');
+  console.log(
+    '  [Path 1] MaintenanceModePolicy — simple return-true block, no structured details.',
+    'Set `enabled: true` in the source to activate.',
+  );
+  console.log(
+    '  [Path 2] MaxRecipientsPolicy   — throws PolicyBlockedError with details.',
+    'Ask the agent to send HBAR to >2 recipients at once to trigger it.',
+  );
+  console.log('');
+  console.log(
+    'When a policy blocks a tool the agent explains it in prose (humanMessage).',
+    'The === Policy Block === section shows the structured data your code can branch on.',
+  );
   console.log('');
 
   while (true) {
@@ -84,17 +135,46 @@ async function bootstrap(): Promise<void> {
         { configurable: { thread_id: '1' } },
       );
 
+      // Print the AI's answer (prose message — what the LLM sees)
+      console.log(`AI: ${response.messages[response.messages.length - 1].content}`);
+
+      // Print the raw tool data as before
       const parsedToolData = responseParsingService.parseNewToolMessages(response);
       const toolCall = parsedToolData[0];
-
-      if (!toolCall) {
-        console.log(`AI: ${response.messages[response.messages.length - 1].content}`);
-      } else {
-        console.log(`AI: ${response.messages[response.messages.length - 1].content}`);
+      if (toolCall) {
         console.log('\n=== Tool Data ===');
         console.log('= Direct tool response =\n', toolCall.parsedData.humanMessage);
         console.log('\n= Full tool response =');
         console.log(JSON.stringify(toolCall.parsedData, null, 2));
+      }
+
+      // -----------------------------------------------------------------------
+      // Parser usage: extract structured policy-block data from the response.
+      //
+      // ResponseParserService.parsePolicyBlocks() runs parseNewToolMessages()
+      // internally, classifies each tool result with classifyToolResult(), and
+      // returns only the `kind: 'policy_block'` entries — typed fields for
+      // programmatic branching without substring-matching the prose message.
+      //
+      // hasPolicyBlocks() is a quick boolean check if you only need to know
+      // whether any block occurred before deciding to call parsePolicyBlocks().
+      // -----------------------------------------------------------------------
+      if (responseParsingService.hasPolicyBlocks(response)) {
+        const policyBlocks = responseParsingService.parsePolicyBlocks(response);
+        console.log('\n=== Policy Block(s) Detected ===');
+        for (const block of policyBlocks) {
+          console.log(`  Policy  : ${block.policyName}`);
+          console.log(`  Stage   : ${block.stage}`);
+          if (block.description) console.log(`  Reason  : ${block.description}`);
+          if (block.details) console.log(`  Details : ${JSON.stringify(block.details)}`);
+          console.log(`  Message : ${block.humanMessage}`);
+          console.log('');
+          // Example of programmatic branching on structured fields:
+          // switch (block.policyName) {
+          //   case 'Maintenance Mode Policy': await notifyOps(block); break;
+          //   case 'Max Recipients Policy':   await queueForReview(block.details); break;
+          // }
+        }
       }
     } catch (err) {
       console.error('Error:', err);

--- a/packages/adk/src/index.ts
+++ b/packages/adk/src/index.ts
@@ -1,3 +1,4 @@
 import HederaADKToolkit from './toolkit';
 
 export { HederaADKToolkit };
+export { PolicyResultParser } from './policyResultParser';

--- a/packages/adk/src/policyResultParser.ts
+++ b/packages/adk/src/policyResultParser.ts
@@ -1,0 +1,100 @@
+import {
+  classifyToolResult,
+  isPolicyBlockedToolResult,
+  type ToolResultStatus,
+} from '@hashgraph/hedera-agent-kit';
+
+/**
+ * Extracts the `{ raw, humanMessage }` envelope from an ADK tool result.
+ *
+ * ADK's `FunctionTool.execute` returns the object directly (a JSON round-trip
+ * is already done inside the wrapper, and bytes are re-hydrated to `Uint8Array`).
+ * This helper handles the three common call shapes:
+ * - Direct `execute()` return: `{ raw, humanMessage }`
+ * - Nested inside an ADK response container: `{ result: { raw, humanMessage } }` (rare)
+ * - Already unwrapped envelope: passed through unchanged
+ */
+function extractEnvelope(adkResult: any): { raw: any; humanMessage: string } | null {
+  if (adkResult == null) return null;
+
+  // Direct shape returned by HederaAgentKitTool.execute: { raw, humanMessage }
+  if (adkResult.raw !== undefined && typeof adkResult.humanMessage === 'string') {
+    return adkResult;
+  }
+
+  // Possible nested shape: { result: { raw, humanMessage } }
+  if (adkResult.result?.raw !== undefined && typeof adkResult.result?.humanMessage === 'string') {
+    return adkResult.result;
+  }
+
+  return null;
+}
+
+/**
+ * Policy-aware result parser for the Google ADK integration.
+ *
+ * Wraps {@link classifyToolResult} with ADK-specific envelope extraction.
+ * ADK tools return a structured object from `execute` (not a string), so the
+ * envelope is available immediately without a separate parse step.
+ *
+ * @example
+ * ```ts
+ * const parser = new PolicyResultParser();
+ *
+ * // After calling a tool directly:
+ * const result = await myAdkTool.execute(args);
+ * const classified = parser.parse(result);
+ * if (classified.kind === 'policy_block') {
+ *   console.log('Blocked by', classified.policyName, classified.details);
+ * }
+ *
+ * // Or batch-filter from an ADK runner's event stream:
+ * const blocks = parser.parsePolicyBlocks(toolCallResults);
+ * ```
+ */
+export class PolicyResultParser {
+  /**
+   * Classify a single ADK tool result into a `ToolResultStatus` discriminated union.
+   *
+   * @param adkResult - The value returned by a Hedera ADK tool's `execute`.
+   * @returns A `ToolResultStatus` (`success | failure | policy_block | parse_error | unknown`).
+   */
+  parse(adkResult: any): ToolResultStatus {
+    const envelope = extractEnvelope(adkResult);
+    if (envelope == null) {
+      return {
+        kind: 'parse_error',
+        originalOutput: adkResult,
+        humanMessage: 'Unable to extract { raw, humanMessage } envelope from ADK tool result.',
+      };
+    }
+    return classifyToolResult(envelope);
+  }
+
+  /**
+   * Quick boolean check — returns `true` if the given ADK tool result was blocked by a policy.
+   *
+   * Prefer {@link parsePolicyBlocks} when you need the structured fields.
+   */
+  isPolicyBlocked(adkResult: any): boolean {
+    const envelope = extractEnvelope(adkResult);
+    return envelope != null && isPolicyBlockedToolResult(envelope);
+  }
+
+  /**
+   * Filter an array of ADK tool results to those that were blocked by a policy.
+   *
+   * Returns only the `kind: 'policy_block'` entries with full typed fields
+   * (`policyName`, `stage`, `details`, etc.).
+   *
+   * @param adkResults - An array of values returned by Hedera ADK tool `execute` calls.
+   */
+  parsePolicyBlocks(adkResults: any[]): Extract<ToolResultStatus, { kind: 'policy_block' }>[] {
+    return adkResults
+      .map((r) => this.parse(r))
+      .filter(
+        (r): r is Extract<ToolResultStatus, { kind: 'policy_block' }> =>
+          r.kind === 'policy_block',
+      );
+  }
+}

--- a/packages/adk/tests/policy-result-parser.unit.test.ts
+++ b/packages/adk/tests/policy-result-parser.unit.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { PolicyResultParser } from '../src/policyResultParser';
+
+const policyBlockEnvelope = {
+  raw: {
+    status: 'ERROR',
+    errorCode: 'POLICY_BLOCKED',
+    error: 'Failed to execute Transfer HBAR: Action transfer_hbar blocked by policy: Max Recipients Policy (Limits the maximum number of recipients to 1)',
+    policyBlock: {
+      code: 'POLICY_BLOCKED',
+      policyName: 'Max Recipients Policy',
+      toolMethod: 'transfer_hbar',
+      stage: 'post_params_normalization',
+      description: 'Limits the maximum number of recipients to 1',
+      details: { recipientCount: 3, maxRecipients: 1 },
+    },
+  },
+  humanMessage: 'Failed to execute Transfer HBAR: Action transfer_hbar blocked by policy: Max Recipients Policy (Limits the maximum number of recipients to 1)',
+};
+
+const successEnvelope = {
+  raw: { status: 'SUCCESS', transactionId: '0.0.1@1.2' },
+  humanMessage: 'Done',
+};
+
+const errorEnvelope = {
+  raw: { status: 'ERROR', error: 'Network timeout' },
+  humanMessage: 'Network timeout',
+};
+
+describe('PolicyResultParser (ADK)', () => {
+  const parser = new PolicyResultParser();
+
+  describe('parse()', () => {
+    it('classifies a direct { raw, humanMessage } policy-block envelope', () => {
+      const result = parser.parse(policyBlockEnvelope);
+      expect(result.kind).toBe('policy_block');
+      if (result.kind === 'policy_block') {
+        expect(result.policyName).toBe('Max Recipients Policy');
+        expect(result.stage).toBe('post_params_normalization');
+        expect(result.details).toEqual({ recipientCount: 3, maxRecipients: 1 });
+      }
+    });
+
+    it('classifies a nested { result: { raw, humanMessage } } shape', () => {
+      const nested = { result: policyBlockEnvelope };
+      const result = parser.parse(nested);
+      expect(result.kind).toBe('policy_block');
+    });
+
+    it('classifies a success envelope', () => {
+      expect(parser.parse(successEnvelope).kind).toBe('success');
+    });
+
+    it('classifies a generic error as failure', () => {
+      expect(parser.parse(errorEnvelope).kind).toBe('failure');
+    });
+
+    it('returns parse_error for null', () => {
+      expect(parser.parse(null).kind).toBe('parse_error');
+    });
+  });
+
+  describe('isPolicyBlocked()', () => {
+    it('returns true for a policy-block envelope', () => {
+      expect(parser.isPolicyBlocked(policyBlockEnvelope)).toBe(true);
+    });
+
+    it('returns false for a success envelope', () => {
+      expect(parser.isPolicyBlocked(successEnvelope)).toBe(false);
+    });
+  });
+
+  describe('parsePolicyBlocks()', () => {
+    it('returns only policy-block entries from a mixed array', () => {
+      const blocks = parser.parsePolicyBlocks([policyBlockEnvelope, successEnvelope, errorEnvelope]);
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].policyName).toBe('Max Recipients Policy');
+    });
+
+    it('returns empty array when no blocks present', () => {
+      expect(parser.parsePolicyBlocks([successEnvelope])).toHaveLength(0);
+    });
+  });
+});

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -2,3 +2,4 @@ import HederaAIToolkit from './toolkit';
 
 export { HederaAIToolkit };
 export { HederaMCPServer } from './mcp-configs';
+export { PolicyResultParser } from './policyResultParser';

--- a/packages/ai-sdk/src/policyResultParser.ts
+++ b/packages/ai-sdk/src/policyResultParser.ts
@@ -1,0 +1,100 @@
+import {
+  classifyToolResult,
+  isPolicyBlockedToolResult,
+  type ToolResultStatus,
+} from '@hashgraph/hedera-agent-kit';
+
+/**
+ * Extracts the `{ raw, humanMessage }` envelope from an AI SDK tool result.
+ *
+ * The Vercel AI SDK preserves the structured object returned by `execute` in
+ * `toolResult.output`. For Hedera tools the result is already a parsed
+ * `{ raw, humanMessage }` envelope (the JSON round-trip and byte hydration are
+ * handled inside the tool wrapper). This helper normalises the three common shapes:
+ * - `toolResult.output` — standard SDK shape
+ * - bare `{ raw, humanMessage }` — direct `execute()` result in tests / AUTONOMOUS mode
+ * - a pre-parsed plain object — passed through unchanged
+ */
+function extractEnvelope(toolResult: any): { raw: any; humanMessage: string } | null {
+  if (toolResult == null) return null;
+
+  // Standard AI SDK shape: { output: { raw, humanMessage } }
+  if (toolResult.output != null && typeof toolResult.output.humanMessage === 'string') {
+    return toolResult.output;
+  }
+
+  // Direct result shape: { raw, humanMessage }
+  if (toolResult.raw !== undefined && typeof toolResult.humanMessage === 'string') {
+    return toolResult;
+  }
+
+  return null;
+}
+
+/**
+ * Policy-aware result parser for the Vercel AI SDK integration.
+ *
+ * Wraps {@link classifyToolResult} with AI-SDK-specific envelope extraction.
+ * Use this when your server calls Hedera tools via `generateText` / `streamText`
+ * and needs to branch on policy blocks rather than parse prose error messages.
+ *
+ * @example
+ * ```ts
+ * const parser = new PolicyResultParser();
+ *
+ * // Inside a generateText loop:
+ * const blocks = parser.parsePolicyBlocks(result.toolResults);
+ * for (const block of blocks) {
+ *   if (block.kind === 'policy_block') {
+ *     switch (block.policyName) {
+ *       case 'Grant Amount Policy':
+ *         await queueForAdminReview({ details: block.details });
+ *         break;
+ *       case 'Grant Review Policy':
+ *         throw new Error('Review metadata failed policy');
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export class PolicyResultParser {
+  /**
+   * Classify a single AI SDK tool result into a `ToolResultStatus` discriminated union.
+   *
+   * @param toolResult - The value returned by a Hedera AI SDK tool's `execute`, or a
+   *   step entry from `result.toolResults` / `result.steps[n].toolResults`.
+   * @returns A `ToolResultStatus` (`success | failure | policy_block | parse_error | unknown`).
+   */
+  parse(toolResult: any): ToolResultStatus {
+    const envelope = extractEnvelope(toolResult);
+    if (envelope == null) {
+      return { kind: 'parse_error', originalOutput: toolResult, humanMessage: 'Unable to extract { raw, humanMessage } envelope from tool result.' };
+    }
+    return classifyToolResult(envelope);
+  }
+
+  /**
+   * Quick boolean check — returns `true` if the given tool result was blocked by a policy.
+   *
+   * Prefer {@link parsePolicyBlocks} when you need the structured fields.
+   */
+  isPolicyBlocked(toolResult: any): boolean {
+    const envelope = extractEnvelope(toolResult);
+    return envelope != null && isPolicyBlockedToolResult(envelope);
+  }
+
+  /**
+   * Filter an array of tool results to those that were blocked by a policy.
+   *
+   * Pass `result.toolResults` or `step.toolResults` from a `generateText` /
+   * `streamText` call. Returns only the `kind: 'policy_block'` entries with
+   * full typed fields (`policyName`, `stage`, `details`, etc.).
+   *
+   * @param toolResults - Any iterable of AI SDK tool result objects.
+   */
+  parsePolicyBlocks(toolResults: any[]): Extract<ToolResultStatus, { kind: 'policy_block' }>[] {
+    return toolResults
+      .map((r) => this.parse(r))
+      .filter((r): r is Extract<ToolResultStatus, { kind: 'policy_block' }> => r.kind === 'policy_block');
+  }
+}

--- a/packages/ai-sdk/tests/policy-result-parser.unit.test.ts
+++ b/packages/ai-sdk/tests/policy-result-parser.unit.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { PolicyResultParser } from '../src/policyResultParser';
+
+const policyBlockEnvelope = {
+  raw: {
+    status: 'ERROR',
+    errorCode: 'POLICY_BLOCKED',
+    error: 'Failed to execute Disburse Grant: Action disburse_grant blocked by policy: Grant Amount Policy (cap)',
+    policyBlock: {
+      code: 'POLICY_BLOCKED',
+      policyName: 'Grant Amount Policy',
+      toolMethod: 'disburse_grant',
+      stage: 'post_params_normalization',
+      description: 'cap',
+      details: { approvedUsd: 750, capUsd: 500 },
+    },
+  },
+  humanMessage: 'Failed to execute Disburse Grant: Action disburse_grant blocked by policy: Grant Amount Policy (cap)',
+};
+
+const successEnvelope = {
+  raw: { status: 'SUCCESS', transactionId: '0.0.1@1.2' },
+  humanMessage: 'Done',
+};
+
+const errorEnvelope = {
+  raw: { status: 'ERROR', error: 'Network error' },
+  humanMessage: 'Network error',
+};
+
+describe('PolicyResultParser (AI SDK)', () => {
+  const parser = new PolicyResultParser();
+
+  describe('parse()', () => {
+    it('classifies a bare { raw, humanMessage } policy-block envelope', () => {
+      const result = parser.parse(policyBlockEnvelope);
+      expect(result.kind).toBe('policy_block');
+      if (result.kind === 'policy_block') {
+        expect(result.policyName).toBe('Grant Amount Policy');
+        expect(result.stage).toBe('post_params_normalization');
+        expect(result.details).toEqual({ approvedUsd: 750, capUsd: 500 });
+      }
+    });
+
+    it('classifies AI SDK output shape: { output: { raw, humanMessage } }', () => {
+      const toolResult = { output: policyBlockEnvelope };
+      const result = parser.parse(toolResult);
+      expect(result.kind).toBe('policy_block');
+    });
+
+    it('classifies a success envelope', () => {
+      expect(parser.parse(successEnvelope).kind).toBe('success');
+    });
+
+    it('classifies a generic error envelope as failure', () => {
+      expect(parser.parse(errorEnvelope).kind).toBe('failure');
+    });
+
+    it('returns parse_error for null', () => {
+      expect(parser.parse(null).kind).toBe('parse_error');
+    });
+
+    it('returns parse_error for opaque string (not an envelope)', () => {
+      expect(parser.parse('{"status":"ERROR"}').kind).toBe('parse_error');
+    });
+  });
+
+  describe('isPolicyBlocked()', () => {
+    it('returns true for a policy-block envelope', () => {
+      expect(parser.isPolicyBlocked(policyBlockEnvelope)).toBe(true);
+    });
+
+    it('returns true for AI SDK { output: envelope } shape', () => {
+      expect(parser.isPolicyBlocked({ output: policyBlockEnvelope })).toBe(true);
+    });
+
+    it('returns false for a success envelope', () => {
+      expect(parser.isPolicyBlocked(successEnvelope)).toBe(false);
+    });
+
+    it('returns false for a generic error envelope', () => {
+      expect(parser.isPolicyBlocked(errorEnvelope)).toBe(false);
+    });
+  });
+
+  describe('parsePolicyBlocks()', () => {
+    it('filters only policy-block entries from a mixed array', () => {
+      const results = [policyBlockEnvelope, successEnvelope, errorEnvelope];
+      const blocks = parser.parsePolicyBlocks(results);
+
+      expect(blocks).toHaveLength(1);
+      expect(blocks[0].policyName).toBe('Grant Amount Policy');
+    });
+
+    it('returns empty array when no policy blocks present', () => {
+      expect(parser.parsePolicyBlocks([successEnvelope, errorEnvelope])).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(parser.parsePolicyBlocks([])).toHaveLength(0);
+    });
+
+    it('handles AI SDK output-shape entries in mixed array', () => {
+      const blocks = parser.parsePolicyBlocks([
+        { output: policyBlockEnvelope },
+        successEnvelope,
+      ]);
+      expect(blocks).toHaveLength(1);
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export { BaseTransactionTool } from './shared/base-transaction-tool';
 export { ToolDiscovery } from './shared/tool-discovery';
 export { default as HederaBuilder } from './shared/hedera-utils/hedera-builder';
 export { AbstractPolicy } from './shared/policy';
+export { PolicyBlockedError, isPolicyBlockedError, POLICY_BLOCK_STAGES } from './shared/policy-blocked-error';
+export type { PolicyBlockStage, PolicyBlockInfo } from './shared/policy-blocked-error';
 export { AbstractHook } from './shared/hook';
 export {
   PreToolExecutionParams,
@@ -39,6 +41,7 @@ export {
   transactionToolOutputParser,
   untypedQueryOutputParser,
   classifyToolResult,
+  isPolicyBlockedToolResult,
   TOOL_STATUS,
 } from './shared/utils/default-tool-output-parsing';
 export type { ToolResultStatus, ToolRawStatus } from './shared/utils/default-tool-output-parsing';

--- a/packages/core/src/policies/max-recipients-policy.ts
+++ b/packages/core/src/policies/max-recipients-policy.ts
@@ -1,4 +1,5 @@
 import { AbstractPolicy, PostParamsNormalizationParams } from '@/shared';
+import { PolicyBlockedError, POLICY_BLOCK_STAGES } from '@/shared/policy-blocked-error';
 import { coreAccountPluginToolNames } from '@/plugins/core-account-plugin';
 import { coreTokenPluginToolNames } from '@/plugins/core-token-plugin';
 import z from 'zod';
@@ -74,7 +75,13 @@ export class MaxRecipientsPolicy extends AbstractPolicy {
       console.warn(
         `MaxRecipientsPolicy: ${method} blocked. Recipient count ${recipientCount} exceeds limit of ${this.maxRecipients}.`,
       );
-      return true;
+      throw new PolicyBlockedError(
+        this.name,
+        method,
+        POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION,
+        this.description,
+        { recipientCount, maxRecipients: this.maxRecipients },
+      );
     }
 
     return false;

--- a/packages/core/src/shared/policy-blocked-error.ts
+++ b/packages/core/src/shared/policy-blocked-error.ts
@@ -1,0 +1,108 @@
+/**
+ * Stage at which a policy blocked tool execution.
+ *
+ * Mirrors the four hook points in {@link AbstractPolicy}:
+ * - `pre_tool_execution` — before params normalization; fired by `preToolExecutionHook`
+ * - `post_params_normalization` — after params are resolved; fired by `postParamsNormalizationHook`
+ * - `post_core_action` — after the core transaction is built; fired by `postCoreActionHook`
+ * - `post_secondary_action` — after signing/execution; fired by `postToolExecutionHook`
+ */
+export const POLICY_BLOCK_STAGES = {
+  PRE_TOOL_EXECUTION: 'pre_tool_execution',
+  POST_PARAMS_NORMALIZATION: 'post_params_normalization',
+  POST_CORE_ACTION: 'post_core_action',
+  POST_SECONDARY_ACTION: 'post_secondary_action',
+} as const;
+
+export type PolicyBlockStage = (typeof POLICY_BLOCK_STAGES)[keyof typeof POLICY_BLOCK_STAGES];
+
+/**
+ * Thrown when a policy blocks tool execution at any hook stage.
+ *
+ * `AbstractPolicy` throws a base `PolicyBlockedError` automatically whenever a
+ * `shouldBlock*` guard returns `true`. Custom policies that need to attach structured
+ * `details` (e.g. `{ approvedUsd, capUsd }`) should throw a `PolicyBlockedError`
+ * (or a typed subclass) directly from `shouldBlock*` instead of returning `true`.
+ *
+ * The `code` field (`'POLICY_BLOCKED'`) is stable and can be used to identify this
+ * error class across module-boundary / bundling mismatches.  Prefer
+ * {@link isPolicyBlockedError} over `instanceof` for that reason.
+ *
+ * @example
+ * ```ts
+ * // Custom policy with structured details
+ * protected shouldBlockPostParamsNormalization(params, method) {
+ *   if (params.normalisedParams.amount > this.cap) {
+ *     throw new PolicyBlockedError(
+ *       this.name, method, POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION,
+ *       this.description,
+ *       { approved: params.normalisedParams.amount, cap: this.cap },
+ *     );
+ *   }
+ *   return false;
+ * }
+ * ```
+ */
+export class PolicyBlockedError extends Error {
+  readonly code = 'POLICY_BLOCKED' as const;
+
+  constructor(
+    public readonly policyName: string,
+    public readonly toolMethod: string,
+    public readonly stage: PolicyBlockStage,
+    public readonly description?: string,
+    public readonly details?: Record<string, unknown>,
+  ) {
+    super(
+      `Action ${toolMethod} blocked by policy: ${policyName}${description ? ` (${description})` : ''}`,
+    );
+    this.name = 'PolicyBlockedError';
+    // Ensure `instanceof` works correctly even when compiled to ES5 and when
+    // a subclass calls super() — required for proper prototype chaining.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Type guard for {@link PolicyBlockedError}.
+ *
+ * Uses both `instanceof` and a duck-typed `code` check so it survives scenarios where
+ * multiple copies of `@hashgraph/hedera-agent-kit` are bundled (the error from one copy
+ * will not be `instanceof` the class in another copy, but the `code` field is stable).
+ */
+export function isPolicyBlockedError(err: unknown): err is PolicyBlockedError {
+  return (
+    err instanceof PolicyBlockedError ||
+    (typeof err === 'object' &&
+      err !== null &&
+      (err as any).code === 'POLICY_BLOCKED' &&
+      typeof (err as any).policyName === 'string')
+  );
+}
+
+/**
+ * Plain-JSON representation of a policy block, stored under `raw.policyBlock` in the
+ * tool result envelope.
+ *
+ * This is the shape that **crosses the `JSON.stringify` boundary** in
+ * `HederaAgentAPI.run()`. The `PolicyBlockedError` instance itself does not survive
+ * serialization; this plain object does.
+ *
+ * Use {@link isPolicyBlockedToolResult} to check whether a `{ raw, humanMessage }`
+ * envelope contains a policy block, or pass the envelope to {@link classifyToolResult}
+ * to get a typed `ToolResultStatus` with `kind: 'policy_block'`.
+ */
+export interface PolicyBlockInfo {
+  /** Stable discriminant. Always `'POLICY_BLOCKED'`. */
+  code: 'POLICY_BLOCKED';
+  /** Display name of the policy that fired (matches `AbstractPolicy.name`). */
+  policyName: string;
+  /** The tool method that was blocked (e.g. `'transfer_hbar'`). */
+  toolMethod: string;
+  /** Hook stage at which the block occurred. */
+  stage: PolicyBlockStage;
+  /** Optional human-readable description from the policy. */
+  description?: string;
+  /** Optional structured details provided by the policy (e.g. `{ recipientCount, maxRecipients }`). */
+  details?: Record<string, unknown>;
+}

--- a/packages/core/src/shared/policy.ts
+++ b/packages/core/src/shared/policy.ts
@@ -5,9 +5,44 @@ import {
   PostCoreActionParams,
   PostSecondaryActionParams,
 } from './hook';
+import { PolicyBlockedError, POLICY_BLOCK_STAGES } from './policy-blocked-error';
 
 /**
- * AbstractPolicy extends AbstractHook and throws errors when validation fails.
+ * AbstractPolicy extends AbstractHook and throws {@link PolicyBlockedError} when
+ * validation fails.
+ *
+ * ## Blocking execution
+ *
+ * The simplest way to block is to return `true` from a `shouldBlock*` guard.
+ * `AbstractPolicy` will automatically throw a base `PolicyBlockedError` with the policy
+ * `name`, `description`, the blocked `toolMethod`, and the hook `stage`.
+ *
+ * If you need to attach **structured details** (e.g. `{ approvedUsd, capUsd }`) to the
+ * block, throw a `PolicyBlockedError` (or a typed subclass) directly from `shouldBlock*`
+ * instead of returning `true`. The error propagates through `BaseTool.execute()`'s
+ * try/catch and is handled by `BaseTool.handleError`, which lifts `policyBlock` info
+ * onto `raw.policyBlock` so it survives JSON serialization.
+ *
+ * @example Returning `true` (simple block, no extra details)
+ * ```ts
+ * protected shouldBlockPreToolExecution(_params, _method) {
+ *   return this.isBlocked;
+ * }
+ * ```
+ *
+ * @example Throwing with structured details
+ * ```ts
+ * protected shouldBlockPostParamsNormalization(params, method) {
+ *   if (params.normalisedParams.amount > this.cap) {
+ *     throw new PolicyBlockedError(
+ *       this.name, method, POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION,
+ *       this.description,
+ *       { approved: params.normalisedParams.amount, cap: this.cap },
+ *     );
+ *   }
+ *   return false;
+ * }
+ * ```
  */
 export abstract class AbstractPolicy extends AbstractHook {
   public abstract name: string;
@@ -64,8 +99,11 @@ export abstract class AbstractPolicy extends AbstractHook {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
     const shouldBlock = await this.shouldBlockPreToolExecution(params, method);
     if (shouldBlock) {
-      throw new Error(
-        `Action ${method} blocked by policy: ${this.name}${this.description ? ` (${this.description})` : ''}`,
+      throw new PolicyBlockedError(
+        this.name,
+        method,
+        POLICY_BLOCK_STAGES.PRE_TOOL_EXECUTION,
+        this.description,
       );
     }
   }
@@ -78,8 +116,11 @@ export abstract class AbstractPolicy extends AbstractHook {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
     const shouldBlock = await this.shouldBlockPostParamsNormalization(params, method);
     if (shouldBlock) {
-      throw new Error(
-        `Action ${method} blocked by policy: ${this.name}${this.description ? ` (${this.description})` : ''}`,
+      throw new PolicyBlockedError(
+        this.name,
+        method,
+        POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION,
+        this.description,
       );
     }
   }
@@ -89,8 +130,11 @@ export abstract class AbstractPolicy extends AbstractHook {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
     const shouldBlock = await this.shouldBlockPostCoreAction(params, method);
     if (shouldBlock) {
-      throw new Error(
-        `Action ${method} blocked by policy: ${this.name}${this.description ? ` (${this.description})` : ''}`,
+      throw new PolicyBlockedError(
+        this.name,
+        method,
+        POLICY_BLOCK_STAGES.POST_CORE_ACTION,
+        this.description,
       );
     }
   }
@@ -103,8 +147,11 @@ export abstract class AbstractPolicy extends AbstractHook {
     if (!this.relevantTools.includes(method)) return; // break execution if this hook does not apply to the current tool
     const shouldBlock = await this.shouldBlockPostSecondaryAction(params, method);
     if (shouldBlock) {
-      throw new Error(
-        `Action ${method} blocked by policy: ${this.name}${this.description ? ` (${this.description})` : ''}`,
+      throw new PolicyBlockedError(
+        this.name,
+        method,
+        POLICY_BLOCK_STAGES.POST_SECONDARY_ACTION,
+        this.description,
       );
     }
   }

--- a/packages/core/src/shared/tools.ts
+++ b/packages/core/src/shared/tools.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { Client } from '@hiero-ledger/sdk';
 import { Context } from './configuration';
 import { TOOL_STATUS } from './utils/default-tool-output-parsing';
+import { isPolicyBlockedError, PolicyBlockInfo } from './policy-blocked-error';
 
 import {
   PreToolExecutionParams,
@@ -33,7 +34,7 @@ export interface Tool {
  * | `raw.status`    | Source                                          | Meaning                                                                 |
  * |-----------------|-------------------------------------------------|-------------------------------------------------------------------------|
  * | `'SUCCESS'`     | `BaseTool.execute()` (defaulted via `??=`), `ReturnBytesStrategy`, or `ExecuteStrategy` | Operation completed successfully. Any tool that reaches the end of `execute()` without an explicit `raw.status` is automatically assigned `'SUCCESS'`. |
- * | `'ERROR'`       | `BaseTool.handleError()` / `BaseTransactionTool.handleError()` | Caught exception. Transaction tools extend `BaseTransactionTool`, which additionally sets `raw.errorCode` (specific SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId` for Hedera receipt/precheck failures. |
+ * | `'ERROR'`       | `BaseTool.handleError()` / `BaseTransactionTool.handleError()` | Caught exception. Transaction tools extend `BaseTransactionTool`, which additionally sets `raw.errorCode` (specific SDK status name, e.g. `'INSUFFICIENT_PAYER_BALANCE'`) and `raw.transactionId` for Hedera receipt/precheck failures. Policy blocks set `raw.errorCode = 'POLICY_BLOCKED'` and `raw.policyBlock` (see `PolicyBlockInfo`). |
  * | `'PARSE_ERROR'` | `transactionToolOutputParser` / `untypedQueryOutputParser` | Output is not valid JSON or has an unexpected shape.                     |
  *
  * Use {@link classifyToolResult} to map these into the stable
@@ -161,15 +162,36 @@ export abstract class BaseTool<TParams = any, TNormalisedParams = any> implement
 
   /**
    * Default error handler called when any step of `execute()` throws.
-   * Returns `{ raw: { status: 'ERROR', error: string }, humanMessage: string }`.
-   * Transaction tools extend `BaseTransactionTool` which overrides this to
-   * additionally extract structured fields from `ReceiptStatusError` and
-   * `PrecheckStatusError`.
+   *
+   * - If the error is a {@link PolicyBlockedError} (thrown by `AbstractPolicy` or a
+   *   custom policy), the structured policy information is lifted onto `raw.policyBlock`
+   *   and `raw.errorCode` is set to `'POLICY_BLOCKED'`. The human-readable `humanMessage`
+   *   is preserved so the LLM agent loop still receives readable feedback.
+   * - For all other errors: returns `{ raw: { status: 'ERROR', error: string }, humanMessage }`.
+   *
+   * Transaction tools extend `BaseTransactionTool` which additionally extracts structured
+   * fields from `ReceiptStatusError` and `PrecheckStatusError`.
    */
   async handleError(error: unknown, _context: Context): Promise<any> {
     const desc = `Failed to execute ${this.name}`;
     const message = desc + (error instanceof Error ? `: ${error.message}` : '');
     console.error(`[${this.method}]`, message);
+
+    if (isPolicyBlockedError(error)) {
+      const policyBlock: PolicyBlockInfo = {
+        code: 'POLICY_BLOCKED',
+        policyName: error.policyName,
+        toolMethod: error.toolMethod,
+        stage: error.stage,
+        ...(error.description !== undefined && { description: error.description }),
+        ...(error.details !== undefined && { details: error.details }),
+      };
+      return {
+        raw: { status: TOOL_STATUS.ERROR, errorCode: 'POLICY_BLOCKED', error: message, policyBlock },
+        humanMessage: message,
+      };
+    }
+
     return { raw: { status: TOOL_STATUS.ERROR, error: message }, humanMessage: message };
   }
 

--- a/packages/core/src/shared/utils/default-tool-output-parsing.ts
+++ b/packages/core/src/shared/utils/default-tool-output-parsing.ts
@@ -1,3 +1,5 @@
+import type { PolicyBlockStage } from '../policy-blocked-error';
+
 /**
  * Shared status constants for the `raw.status` field.
  *
@@ -157,7 +159,7 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
 
 /**
  * Discriminated union describing a tool result that has been classified into
- * a stable success / failure / parse_error / unknown shape.
+ * a stable success / failure / policy_block / parse_error / unknown shape.
  *
  * - `success`: `raw.status === 'SUCCESS'`. `data` exposes the original `raw`
  *   payload typed as `T`. `transactionId` is lifted out when present.
@@ -166,6 +168,11 @@ export const untypedQueryOutputParser = (rawOutput: string): { raw: any; humanMe
  *   the failure was a Hedera network receipt or precheck error, or `'ERROR'` for
  *   generic caught exceptions. `transactionId` is lifted out when present
  *   (receipt and precheck failures both set it).
+ * - `policy_block`: `raw.errorCode === 'POLICY_BLOCKED'` and `raw.policyBlock`
+ *   is present. Carries the structured policy block info: `policyName`, `toolMethod`,
+ *   `stage`, and optional `description` / `details`. The LLM-facing `humanMessage`
+ *   is preserved. Use {@link isPolicyBlockedToolResult} as a quick envelope-level
+ *   guard before classifying.
  * - `parse_error`: `raw.status === 'PARSE_ERROR'` or the envelope was
  *   structurally malformed (missing `raw`, non-object, etc.).
  * - `unknown`: `raw.status` is a non-empty string that does not match any of
@@ -180,6 +187,16 @@ export type ToolResultStatus<T = unknown> =
       kind: 'failure';
       errorCode: string;
       transactionId?: string;
+      error: string;
+      humanMessage: string;
+    }
+  | {
+      kind: 'policy_block';
+      policyName: string;
+      toolMethod: string;
+      stage: PolicyBlockStage;
+      description?: string;
+      details?: Record<string, unknown>;
       error: string;
       humanMessage: string;
     }
@@ -244,6 +261,25 @@ export const classifyToolResult = <T = unknown>(parsed: {
     };
   }
 
+  // Policy block — check before the generic failure branch so it gets a dedicated `kind`.
+  if (
+    raw.policyBlock &&
+    typeof raw.policyBlock === 'object' &&
+    raw.policyBlock.code === 'POLICY_BLOCKED'
+  ) {
+    const pb = raw.policyBlock;
+    return {
+      kind: 'policy_block',
+      policyName: pb.policyName,
+      toolMethod: pb.toolMethod,
+      stage: pb.stage,
+      ...(pb.description !== undefined && { description: pb.description }),
+      ...(pb.details !== undefined && { details: pb.details }),
+      error: typeof raw.error === 'string' ? raw.error : humanMessage,
+      humanMessage,
+    };
+  }
+
   if (raw.status === TOOL_STATUS.ERROR || typeof raw.error === 'string') {
     return {
       kind: 'failure',
@@ -263,3 +299,33 @@ export const classifyToolResult = <T = unknown>(parsed: {
 
   return { kind: 'unknown', humanMessage };
 };
+
+/**
+ * Quick envelope-level guard that returns `true` when a `{ raw, humanMessage }` envelope
+ * was produced by a policy block (i.e. `raw.policyBlock.code === 'POLICY_BLOCKED'`).
+ *
+ * Use this for a fast boolean check before you need the full structured data. To branch on
+ * individual fields pass the envelope to {@link classifyToolResult} and check
+ * `result.kind === 'policy_block'`.
+ *
+ * @example
+ * ```ts
+ * const envelope = transactionToolOutputParser(rawOutput);
+ * if (isPolicyBlockedToolResult(envelope)) {
+ *   const result = classifyToolResult(envelope);
+ *   if (result.kind === 'policy_block') {
+ *     console.log(result.policyName, result.details);
+ *   }
+ * }
+ * ```
+ */
+export function isPolicyBlockedToolResult(parsed: { raw: any; humanMessage: string }): boolean {
+  return (
+    parsed != null &&
+    typeof parsed.raw === 'object' &&
+    parsed.raw !== null &&
+    typeof parsed.raw.policyBlock === 'object' &&
+    parsed.raw.policyBlock !== null &&
+    parsed.raw.policyBlock.code === 'POLICY_BLOCKED'
+  );
+}

--- a/packages/core/tests/integration/policy/max-recipients-policy.integration.test.ts
+++ b/packages/core/tests/integration/policy/max-recipients-policy.integration.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { MaxRecipientsPolicy } from '@/policies/max-recipients-policy';
 import { Context, AgentMode } from '@/shared';
+import { classifyToolResult, isPolicyBlockedToolResult } from '@/shared/utils/default-tool-output-parsing';
 import { getProfile } from '@hashgraph/hedera-agent-kit-tests';
 import { Client } from '@hiero-ledger/sdk';
 import transferHbarTool from '@/plugins/core-account-plugin/tools/account/transfer-hbar';
+import { TRANSFER_HBAR_TOOL } from '@/plugins/core-account-plugin/tools/account/transfer-hbar';
 
 describe('MaxRecipientsPolicy Integration Tests', () => {
   const profile = getProfile();
@@ -17,42 +19,117 @@ describe('MaxRecipientsPolicy Integration Tests', () => {
     operatorClient?.close();
   });
 
-  it('should block TRANSFER_HBAR_TOOL if recipients count exceeds limit', async () => {
-    const policy = new MaxRecipientsPolicy(1);
-    const context: Context = {
-      mode: AgentMode.AUTONOMOUS,
-      hooks: [policy],
-    };
+  describe('when recipients exceed the cap (throw-with-details path)', () => {
+    it('preserves the prose humanMessage for the LLM loop', async () => {
+      const policy = new MaxRecipientsPolicy(1);
+      const context: Context = { mode: AgentMode.AUTONOMOUS, hooks: [policy] };
+      const tool = transferHbarTool(context);
+      const params = {
+        transfers: [
+          { accountId: '0.0.1', amount: 0.1 },
+          { accountId: '0.0.2', amount: 0.1 },
+        ],
+      };
 
-    const tool = transferHbarTool(context);
-    const params = {
-      transfers: [
-        { accountId: '0.0.1', amount: 0.1 },
-        { accountId: '0.0.2', amount: 0.1 },
-      ],
-    };
+      const result = await tool.execute(operatorClient, context, params);
 
-    const result = await tool.execute(operatorClient, context, params);
+      expect(result.humanMessage).toContain('blocked by policy: Max Recipients Policy');
+      expect(result.humanMessage).toContain('Limits the maximum number of recipients to 1');
+      expect(result.raw.status).toBe('ERROR');
+    });
 
-    expect(result.raw.error).toContain('blocked by policy: Max Recipients Policy');
-    expect(result.raw.error).toContain('Limits the maximum number of recipients to 1');
+    it('sets errorCode POLICY_BLOCKED on raw', async () => {
+      const policy = new MaxRecipientsPolicy(1);
+      const context: Context = { mode: AgentMode.AUTONOMOUS, hooks: [policy] };
+      const tool = transferHbarTool(context);
+      const params = {
+        transfers: [
+          { accountId: '0.0.1', amount: 0.1 },
+          { accountId: '0.0.2', amount: 0.1 },
+        ],
+      };
+
+      const result = await tool.execute(operatorClient, context, params);
+
+      expect(result.raw.errorCode).toBe('POLICY_BLOCKED');
+    });
+
+    it('populates raw.policyBlock with structured fields including details', async () => {
+      const policy = new MaxRecipientsPolicy(1);
+      const context: Context = { mode: AgentMode.AUTONOMOUS, hooks: [policy] };
+      const tool = transferHbarTool(context);
+      const params = {
+        transfers: [
+          { accountId: '0.0.1', amount: 0.1 },
+          { accountId: '0.0.2', amount: 0.1 },
+        ],
+      };
+
+      const result = await tool.execute(operatorClient, context, params);
+
+      expect(result.raw.policyBlock).toMatchObject({
+        code: 'POLICY_BLOCKED',
+        policyName: 'Max Recipients Policy',
+        toolMethod: TRANSFER_HBAR_TOOL,
+        stage: 'post_params_normalization',
+        description: 'Limits the maximum number of recipients to 1',
+        details: { recipientCount: 2, maxRecipients: 1 },
+      });
+    });
+
+    it('classifyToolResult returns kind: policy_block with typed fields', async () => {
+      const policy = new MaxRecipientsPolicy(1);
+      const context: Context = { mode: AgentMode.AUTONOMOUS, hooks: [policy] };
+      const tool = transferHbarTool(context);
+      const params = {
+        transfers: [
+          { accountId: '0.0.1', amount: 0.1 },
+          { accountId: '0.0.2', amount: 0.1 },
+        ],
+      };
+
+      const result = await tool.execute(operatorClient, context, params);
+      const classified = classifyToolResult(result);
+
+      expect(classified.kind).toBe('policy_block');
+      if (classified.kind === 'policy_block') {
+        expect(classified.policyName).toBe('Max Recipients Policy');
+        expect(classified.stage).toBe('post_params_normalization');
+        expect(classified.details).toEqual({ recipientCount: 2, maxRecipients: 1 });
+      }
+    });
+
+    it('isPolicyBlockedToolResult returns true for a blocked result', async () => {
+      const policy = new MaxRecipientsPolicy(1);
+      const context: Context = { mode: AgentMode.AUTONOMOUS, hooks: [policy] };
+      const tool = transferHbarTool(context);
+      const params = {
+        transfers: [
+          { accountId: '0.0.1', amount: 0.1 },
+          { accountId: '0.0.2', amount: 0.1 },
+        ],
+      };
+
+      const result = await tool.execute(operatorClient, context, params);
+
+      expect(isPolicyBlockedToolResult(result)).toBe(true);
+    });
   });
 
-  it('should allow TRANSFER_HBAR_TOOL if recipients count is within limit', async () => {
-    const policy = new MaxRecipientsPolicy(10);
-    const context: Context = {
-      mode: AgentMode.AUTONOMOUS,
-      hooks: [policy],
-    };
+  describe('when recipients are within the cap', () => {
+    it('allows the tool to proceed and returns no policy block', async () => {
+      const policy = new MaxRecipientsPolicy(10);
+      const context: Context = { mode: AgentMode.AUTONOMOUS, hooks: [policy] };
+      const tool = transferHbarTool(context);
+      const params = {
+        transfers: [{ accountId: '0.0.1', amount: 0.1 }],
+      };
 
-    const tool = transferHbarTool(context);
-    const params = {
-      transfers: [{ accountId: '0.0.1', amount: 0.1 }],
-    };
+      const result = await tool.execute(operatorClient, context, params);
 
-    const result = await tool.execute(operatorClient, context, params);
-
-    // It should NOT have the policy error
-    expect(result.raw.error).not.toBeDefined();
+      expect(result.raw.errorCode).toBeUndefined();
+      expect(result.raw.policyBlock).toBeUndefined();
+      expect(isPolicyBlockedToolResult(result)).toBe(false);
+    });
   });
 });

--- a/packages/core/tests/integration/policy/reject-tool-policy.integration.test.ts
+++ b/packages/core/tests/integration/policy/reject-tool-policy.integration.test.ts
@@ -30,12 +30,21 @@ describe('reject tool policy integration tests', () => {
     const tool = getHbarBalanceTool(context);
     const params = { accountId: profile.operator.accountId.toString() };
 
-    await expect(tool.execute(operatorClient, context, params)).resolves.toEqual({
-      raw: {
-        error: `Failed to execute Get HBAR Balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`,
-        status: 'ERROR',
-      },
-      humanMessage: `Failed to execute Get HBAR Balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`,
+    const result = await tool.execute(operatorClient, context, params);
+
+    // Prose message is preserved for the LLM loop
+    const expectedMessage = `Failed to execute Get HBAR Balance: Action ${GET_HBAR_BALANCE_QUERY_TOOL} blocked by policy: Reject Tool Call (Stops agent from calling predefined tools)`;
+    expect(result.raw.error).toBe(expectedMessage);
+    expect(result.raw.status).toBe('ERROR');
+    expect(result.raw.errorCode).toBe('POLICY_BLOCKED');
+    expect(result.humanMessage).toBe(expectedMessage);
+
+    // Structured policy block info for programmatic loops
+    expect(result.raw.policyBlock).toMatchObject({
+      code: 'POLICY_BLOCKED',
+      policyName: 'Reject Tool Call',
+      toolMethod: GET_HBAR_BALANCE_QUERY_TOOL,
+      stage: 'pre_tool_execution',
     });
   });
 

--- a/packages/core/tests/unit/policy/max-recipients-policy.unit.test.ts
+++ b/packages/core/tests/unit/policy/max-recipients-policy.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MaxRecipientsPolicy } from '@/policies/max-recipients-policy';
+import { PolicyBlockedError, POLICY_BLOCK_STAGES } from '@/shared/policy-blocked-error';
 import { Context, AgentMode } from '@/shared';
 import { Client, Hbar } from '@hiero-ledger/sdk';
 import { coreAccountPluginToolNames } from '@/plugins/core-account-plugin';
@@ -49,12 +50,21 @@ describe('MaxRecipientsPolicy Unit Tests', () => {
         },
       };
 
-      expect(
-        policy['shouldBlockPostParamsNormalization'](
-          params,
-          coreAccountPluginToolNames.TRANSFER_HBAR_TOOL,
-        ),
-      ).toBe(true);
+      const method = coreAccountPluginToolNames.TRANSFER_HBAR_TOOL;
+      expect(() => policy['shouldBlockPostParamsNormalization'](params, method)).toThrow(
+        PolicyBlockedError,
+      );
+
+      try {
+        policy['shouldBlockPostParamsNormalization'](params, method);
+      } catch (err) {
+        expect(err).toBeInstanceOf(PolicyBlockedError);
+        const e = err as PolicyBlockedError;
+        expect(e.policyName).toBe('Max Recipients Policy');
+        expect(e.toolMethod).toBe(method);
+        expect(e.stage).toBe(POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION);
+        expect(e.details).toEqual({ recipientCount: 2, maxRecipients: 1 });
+      }
     });
 
     it('should not block if positive-amount hbar recipients are within maxRecipients', () => {
@@ -99,12 +109,10 @@ describe('MaxRecipientsPolicy Unit Tests', () => {
         },
       };
 
-      expect(
-        policy['shouldBlockPostParamsNormalization'](
-          params,
-          coreAccountPluginToolNames.TRANSFER_HBAR_TOOL,
-        ),
-      ).toBe(true);
+      const method = coreAccountPluginToolNames.TRANSFER_HBAR_TOOL;
+      expect(() => policy['shouldBlockPostParamsNormalization'](params, method)).toThrow(
+        PolicyBlockedError,
+      );
     });
 
     it('should not count zero-amount entries as recipients', () => {
@@ -147,12 +155,10 @@ describe('MaxRecipientsPolicy Unit Tests', () => {
         },
       };
 
-      expect(
-        policy['shouldBlockPostParamsNormalization'](
-          params,
-          coreTokenPluginToolNames.AIRDROP_FUNGIBLE_TOKEN_TOOL,
-        ),
-      ).toBe(true);
+      const method = coreTokenPluginToolNames.AIRDROP_FUNGIBLE_TOKEN_TOOL;
+      expect(() => policy['shouldBlockPostParamsNormalization'](params, method)).toThrow(
+        PolicyBlockedError,
+      );
     });
 
     it('should not block if positive-amount token recipients are within maxRecipients', () => {
@@ -194,12 +200,18 @@ describe('MaxRecipientsPolicy Unit Tests', () => {
         },
       };
 
-      expect(
-        policy['shouldBlockPostParamsNormalization'](
-          params,
-          coreTokenPluginToolNames.TRANSFER_NON_FUNGIBLE_TOKEN_TOOL,
-        ),
-      ).toBe(true);
+      const method = coreTokenPluginToolNames.TRANSFER_NON_FUNGIBLE_TOKEN_TOOL;
+      expect(() => policy['shouldBlockPostParamsNormalization'](params, method)).toThrow(
+        PolicyBlockedError,
+      );
+
+      try {
+        policy['shouldBlockPostParamsNormalization'](params, method);
+      } catch (err) {
+        expect(err).toBeInstanceOf(PolicyBlockedError);
+        const e = err as PolicyBlockedError;
+        expect(e.details).toEqual({ recipientCount: 2, maxRecipients: 1 });
+      }
     });
 
     it('should not block if NFT recipients are within maxRecipients', () => {
@@ -226,7 +238,7 @@ describe('MaxRecipientsPolicy Unit Tests', () => {
   });
 
   describe('Custom Strategies', () => {
-    it('should use custom strategy when provided', () => {
+    it('should use custom strategy when provided and block when exceeded', () => {
       const customStrategy = (params: any) => params.customRecipients.length;
       const policy = new MaxRecipientsPolicy(1, ['my_custom_tool'], {
         my_custom_tool: customStrategy,
@@ -241,7 +253,9 @@ describe('MaxRecipientsPolicy Unit Tests', () => {
         },
       };
 
-      expect(policy['shouldBlockPostParamsNormalization'](params, 'my_custom_tool')).toBe(true);
+      expect(() =>
+        policy['shouldBlockPostParamsNormalization'](params, 'my_custom_tool'),
+      ).toThrow(PolicyBlockedError);
     });
 
     it('should block if tool is unhandled and no custom strategy is provided', () => {

--- a/packages/core/tests/unit/policy/policy-blocked-error.unit.test.ts
+++ b/packages/core/tests/unit/policy/policy-blocked-error.unit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PolicyBlockedError,
+  isPolicyBlockedError,
+  POLICY_BLOCK_STAGES,
+  type PolicyBlockStage,
+} from '@/shared/policy-blocked-error';
+
+describe('PolicyBlockedError', () => {
+  const stage: PolicyBlockStage = POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION;
+
+  describe('constructor', () => {
+    it('sets all fields correctly', () => {
+      const err = new PolicyBlockedError(
+        'Grant Amount Policy',
+        'disburse_grant',
+        stage,
+        'Blocks payouts above the cap',
+        { approvedUsd: 750, capUsd: 500 },
+      );
+
+      expect(err.code).toBe('POLICY_BLOCKED');
+      expect(err.policyName).toBe('Grant Amount Policy');
+      expect(err.toolMethod).toBe('disburse_grant');
+      expect(err.stage).toBe('post_params_normalization');
+      expect(err.description).toBe('Blocks payouts above the cap');
+      expect(err.details).toEqual({ approvedUsd: 750, capUsd: 500 });
+    });
+
+    it('sets name to PolicyBlockedError', () => {
+      const err = new PolicyBlockedError('P', 'm', POLICY_BLOCK_STAGES.PRE_TOOL_EXECUTION);
+      expect(err.name).toBe('PolicyBlockedError');
+    });
+
+    it('produces a human-readable message with description', () => {
+      const err = new PolicyBlockedError('My Policy', 'my_tool', stage, 'some description');
+      expect(err.message).toBe('Action my_tool blocked by policy: My Policy (some description)');
+    });
+
+    it('produces a human-readable message without description', () => {
+      const err = new PolicyBlockedError('My Policy', 'my_tool', stage);
+      expect(err.message).toBe('Action my_tool blocked by policy: My Policy');
+    });
+
+    it('is an instance of Error', () => {
+      const err = new PolicyBlockedError('P', 'm', stage);
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('description and details are optional', () => {
+      const err = new PolicyBlockedError('P', 'm', stage);
+      expect(err.description).toBeUndefined();
+      expect(err.details).toBeUndefined();
+    });
+  });
+
+  describe('POLICY_BLOCK_STAGES', () => {
+    it('has the four expected string values', () => {
+      expect(POLICY_BLOCK_STAGES.PRE_TOOL_EXECUTION).toBe('pre_tool_execution');
+      expect(POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION).toBe('post_params_normalization');
+      expect(POLICY_BLOCK_STAGES.POST_CORE_ACTION).toBe('post_core_action');
+      expect(POLICY_BLOCK_STAGES.POST_SECONDARY_ACTION).toBe('post_secondary_action');
+    });
+  });
+
+  describe('isPolicyBlockedError', () => {
+    it('returns true for a PolicyBlockedError instance', () => {
+      const err = new PolicyBlockedError('P', 'm', stage);
+      expect(isPolicyBlockedError(err)).toBe(true);
+    });
+
+    it('returns true for a duck-typed object with code POLICY_BLOCKED and policyName', () => {
+      const fakeErr = { code: 'POLICY_BLOCKED', policyName: 'SomePolicy', message: 'blocked' };
+      expect(isPolicyBlockedError(fakeErr)).toBe(true);
+    });
+
+    it('returns false for a plain Error', () => {
+      expect(isPolicyBlockedError(new Error('something'))).toBe(false);
+    });
+
+    it('returns false for null', () => {
+      expect(isPolicyBlockedError(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isPolicyBlockedError(undefined)).toBe(false);
+    });
+
+    it('returns false for a string', () => {
+      expect(isPolicyBlockedError('POLICY_BLOCKED')).toBe(false);
+    });
+
+    it('returns false for an object with wrong code', () => {
+      expect(isPolicyBlockedError({ code: 'OTHER', policyName: 'P' })).toBe(false);
+    });
+
+    it('returns false for an object with correct code but no policyName', () => {
+      expect(isPolicyBlockedError({ code: 'POLICY_BLOCKED' })).toBe(false);
+    });
+  });
+
+  describe('subclass instanceof', () => {
+    it('a PolicyBlockedError subclass is instanceof PolicyBlockedError and Error', () => {
+      class CustomPolicyError extends PolicyBlockedError {
+        constructor(public readonly amountUsd: number) {
+          super(
+            'Custom Policy',
+            'custom_tool',
+            POLICY_BLOCK_STAGES.POST_PARAMS_NORMALIZATION,
+            'Custom block',
+            { amountUsd },
+          );
+        }
+      }
+
+      const err = new CustomPolicyError(750);
+      expect(err).toBeInstanceOf(PolicyBlockedError);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.code).toBe('POLICY_BLOCKED');
+      expect(isPolicyBlockedError(err)).toBe(true);
+      expect(err.amountUsd).toBe(750);
+    });
+  });
+});

--- a/packages/core/tests/unit/policy/reject-tool-policy.unit.test.ts
+++ b/packages/core/tests/unit/policy/reject-tool-policy.unit.test.ts
@@ -1,10 +1,11 @@
 import { RejectToolPolicy } from '@/policies/reject-tool-policy';
 import { describe, it, expect } from 'vitest';
 import { AbstractPolicy } from '@/shared';
+import { PolicyBlockedError, POLICY_BLOCK_STAGES } from '@/shared/policy-blocked-error';
 import { Client } from '@hiero-ledger/sdk';
 
 describe('RejectToolPolicy', async () => {
-  it('should reject a tool call by returning true', async () => {
+  it('should block a tool call with a PolicyBlockedError at PRE_TOOL_EXECUTION stage', async () => {
     const relevantTools = ['toolA', 'toolB'];
     const policy = new RejectToolPolicy(relevantTools);
     const context = {} as any; // mock context
@@ -13,8 +14,19 @@ describe('RejectToolPolicy', async () => {
     const method = 'toolA';
 
     await expect((policy as AbstractPolicy).preToolExecutionHook(params, method)).rejects.toThrow(
-      new RegExp(`Action ${method} blocked by policy: Reject Tool Call ( \\(.+\\))?`),
+      PolicyBlockedError,
     );
+
+    try {
+      await (policy as AbstractPolicy).preToolExecutionHook(params, method);
+    } catch (err) {
+      expect(err).toBeInstanceOf(PolicyBlockedError);
+      const e = err as PolicyBlockedError;
+      expect(e.policyName).toBe('Reject Tool Call');
+      expect(e.toolMethod).toBe(method);
+      expect(e.stage).toBe(POLICY_BLOCK_STAGES.PRE_TOOL_EXECUTION);
+      expect(e.message).toMatch(new RegExp(`Action ${method} blocked by policy: Reject Tool Call`));
+    }
   });
 
   it('should not reject a tool call if the tool is not relevant', async () => {

--- a/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
+++ b/packages/core/tests/unit/utils/classify-tool-result.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyToolResult,
+  isPolicyBlockedToolResult,
   transactionToolOutputParser,
   type ToolResultStatus,
 } from '@/shared/utils/default-tool-output-parsing';
@@ -212,6 +213,137 @@ describe('classifyToolResult', () => {
       });
 
       expect(result.kind).toBe('unknown');
+    });
+  });
+
+  describe('policy_block', () => {
+    const policyBlockRaw = {
+      raw: {
+        status: 'ERROR',
+        errorCode: 'POLICY_BLOCKED',
+        error: 'Failed to execute Disburse Grant: Action disburse_grant blocked by policy: Grant Amount Policy (Blocks payouts above the configured auto-pay USD cap)',
+        policyBlock: {
+          code: 'POLICY_BLOCKED',
+          policyName: 'Grant Amount Policy',
+          toolMethod: 'disburse_grant',
+          stage: 'post_params_normalization',
+          description: 'Blocks payouts above the configured auto-pay USD cap',
+          details: { approvedUsd: 750, capUsd: 500 },
+        },
+      },
+      humanMessage: 'Failed to execute Disburse Grant: Action disburse_grant blocked by policy: Grant Amount Policy (Blocks payouts above the configured auto-pay USD cap)',
+    };
+
+    it('classifies a policy-block envelope as policy_block kind', () => {
+      const result = classifyToolResult(policyBlockRaw);
+
+      expect(result.kind).toBe('policy_block');
+      if (result.kind === 'policy_block') {
+        expect(result.policyName).toBe('Grant Amount Policy');
+        expect(result.toolMethod).toBe('disburse_grant');
+        expect(result.stage).toBe('post_params_normalization');
+        expect(result.description).toBe('Blocks payouts above the configured auto-pay USD cap');
+        expect(result.details).toEqual({ approvedUsd: 750, capUsd: 500 });
+        expect(result.error).toContain('blocked by policy: Grant Amount Policy');
+        expect(result.humanMessage).toContain('Disburse Grant');
+      }
+    });
+
+    it('policy_block without details returns undefined details', () => {
+      const envelope = {
+        raw: {
+          status: 'ERROR',
+          errorCode: 'POLICY_BLOCKED',
+          error: 'Failed to execute foo: Action foo blocked by policy: Reject Tool Call',
+          policyBlock: {
+            code: 'POLICY_BLOCKED',
+            policyName: 'Reject Tool Call',
+            toolMethod: 'foo',
+            stage: 'pre_tool_execution',
+          },
+        },
+        humanMessage: 'Failed to execute foo: Action foo blocked by policy: Reject Tool Call',
+      };
+
+      const result = classifyToolResult(envelope);
+      expect(result.kind).toBe('policy_block');
+      if (result.kind === 'policy_block') {
+        expect(result.policyName).toBe('Reject Tool Call');
+        expect(result.stage).toBe('pre_tool_execution');
+        expect(result.details).toBeUndefined();
+      }
+    });
+
+    it('policy_block survives JSON round-trip (as it would through HederaAgentAPI.run)', () => {
+      const serialized = JSON.stringify({ result: policyBlockRaw });
+      const parsed = JSON.parse(serialized).result;
+      const result = classifyToolResult(parsed);
+
+      expect(result.kind).toBe('policy_block');
+      if (result.kind === 'policy_block') {
+        expect(result.policyName).toBe('Grant Amount Policy');
+        expect(result.details).toEqual({ approvedUsd: 750, capUsd: 500 });
+      }
+    });
+
+    it('policy_block takes precedence over the generic failure branch', () => {
+      // raw.status is ERROR which would match the failure branch — policy_block must fire first
+      const result = classifyToolResult(policyBlockRaw);
+      expect(result.kind).toBe('policy_block');
+      expect(result.kind).not.toBe('failure');
+    });
+  });
+
+  describe('isPolicyBlockedToolResult', () => {
+    it('returns true for a valid policy-block envelope', () => {
+      const envelope = {
+        raw: {
+          status: 'ERROR',
+          errorCode: 'POLICY_BLOCKED',
+          error: 'blocked',
+          policyBlock: {
+            code: 'POLICY_BLOCKED',
+            policyName: 'SomePolicy',
+            toolMethod: 'foo',
+            stage: 'pre_tool_execution',
+          },
+        },
+        humanMessage: 'blocked',
+      };
+      expect(isPolicyBlockedToolResult(envelope)).toBe(true);
+    });
+
+    it('returns false for a normal ERROR envelope', () => {
+      expect(
+        isPolicyBlockedToolResult({
+          raw: { status: 'ERROR', error: 'something went wrong' },
+          humanMessage: 'something went wrong',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false for a SUCCESS envelope', () => {
+      expect(
+        isPolicyBlockedToolResult({
+          raw: { status: 'SUCCESS' },
+          humanMessage: 'done',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when raw is null', () => {
+      expect(
+        isPolicyBlockedToolResult({ raw: null as any, humanMessage: '' }),
+      ).toBe(false);
+    });
+
+    it('returns false when policyBlock.code does not match', () => {
+      expect(
+        isPolicyBlockedToolResult({
+          raw: { policyBlock: { code: 'SOMETHING_ELSE' } },
+          humanMessage: '',
+        }),
+      ).toBe(false);
     });
   });
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -93,6 +93,12 @@ console.log(parsed[0].toolName);   // e.g. "create_account_tool"
 console.log(parsed[0].parsedData); // tool execution result
 ```
 
+`ResponseParserService` also exposes `parsePolicyBlocks(response)` and
+`hasPolicyBlocks(response)` for surfacing structured policy-block data without parsing
+prose. See
+[Blocking with Policies](../../docs/HOOKS_AND_POLICIES.md#blocking-with-policies) for
+details and a usage snippet.
+
 ## Streaming
 
 When streaming with `agent.streamEvents({ version: 'v2' })`, the `on_tool_start` event's `name` is the shared wrapper class (`HederaAgentKitTool`). To label steps with the real tool name, read it from `event.metadata.hakToolName`:

--- a/packages/langchain/src/responseParserService.ts
+++ b/packages/langchain/src/responseParserService.ts
@@ -1,5 +1,5 @@
 import { BaseMessage, ToolMessage } from '@langchain/core/messages';
-import { toUint8Array } from '@hashgraph/hedera-agent-kit';
+import { toUint8Array, classifyToolResult, isPolicyBlockedToolResult, type ToolResultStatus } from '@hashgraph/hedera-agent-kit';
 import HederaAgentKitTool from './tool';
 
 // RETURN_BYTES output is JSON text, so `bytes` arrives as a Buffer/numeric-keyed object rather
@@ -121,6 +121,67 @@ class ResponseParserService {
     }
 
     return allParsedData;
+  }
+
+  /**
+   * Parse all new ToolMessages and return only those that were blocked by a policy.
+   *
+   * Internally calls {@link parseNewToolMessages} (which applies the same dedup logic
+   * via `processedMessageIds`), then classifies each parsed envelope and filters to
+   * `kind: 'policy_block'` results. The structured `policyName`, `stage`, `details`,
+   * etc. fields are available on each entry.
+   *
+   * @example
+   * ```ts
+   * const parser = new ResponseParserService(toolkit.getTools());
+   * const { messages } = await agent.invoke(input);
+   *
+   * const blocks = parser.parsePolicyBlocks({ messages });
+   * for (const block of blocks) {
+   *   switch (block.policyName) {
+   *     case 'Grant Amount Policy':
+   *       await queueForAdminReview({ details: block.details });
+   *       break;
+   *     case 'Grant Review Policy':
+   *       throw new Error('Review metadata failed policy');
+   *   }
+   * }
+   * ```
+   *
+   * @param response - The agent response object with a `messages` array.
+   */
+  parsePolicyBlocks(response: AgentResponse): Extract<ToolResultStatus, { kind: 'policy_block' }>[] {
+    const parsed = this.parseNewToolMessages(response);
+    return parsed
+      .map(({ parsedData }) => {
+        // parsedData is the { raw, humanMessage } envelope (bytes already hydrated)
+        if (typeof parsedData?.humanMessage === 'string' && parsedData?.raw !== undefined) {
+          return classifyToolResult(parsedData as { raw: any; humanMessage: string });
+        }
+        return { kind: 'unknown' as const, humanMessage: '' } satisfies ToolResultStatus;
+      })
+      .filter(
+        (r): r is Extract<ToolResultStatus, { kind: 'policy_block' }> =>
+          r.kind === 'policy_block',
+      );
+  }
+
+  /**
+   * Quick boolean check — returns `true` if *any* new tool message in the response
+   * was blocked by a policy.
+   *
+   * Note: this marks the matched messages as processed in `processedMessageIds`,
+   * just like {@link parseNewToolMessages} does. Create a fresh `ResponseParserService`
+   * instance per request if you need idempotent checks.
+   */
+  hasPolicyBlocks(response: AgentResponse): boolean {
+    const parsed = this.parseNewToolMessages(response);
+    return parsed.some(({ parsedData }) => {
+      if (typeof parsedData?.humanMessage === 'string' && parsedData?.raw !== undefined) {
+        return isPolicyBlockedToolResult(parsedData as { raw: any; humanMessage: string });
+      }
+      return false;
+    });
   }
 }
 

--- a/packages/langchain/tests/unit/policy-result-parser.unit.test.ts
+++ b/packages/langchain/tests/unit/policy-result-parser.unit.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import ResponseParserService from '../../src/responseParserService';
+
+// Minimal stub for ToolMessage compatible with the is-tool-message guard:
+// { type: 'tool', tool_call_id, name, id, content }
+function makeToolMessage(name: string, content: string): any {
+  return {
+    type: 'tool',
+    tool_call_id: `call_${name}`,
+    name,
+    id: `msg_${name}_${Math.random()}`,
+    content,
+  };
+}
+
+const policyBlockEnvelope = {
+  raw: {
+    status: 'ERROR',
+    errorCode: 'POLICY_BLOCKED',
+    error: 'Failed to execute Transfer HBAR: Action transfer_hbar blocked by policy: Max Recipients Policy',
+    policyBlock: {
+      code: 'POLICY_BLOCKED',
+      policyName: 'Max Recipients Policy',
+      toolMethod: 'transfer_hbar',
+      stage: 'post_params_normalization',
+      details: { recipientCount: 3, maxRecipients: 1 },
+    },
+  },
+  humanMessage: 'Failed to execute Transfer HBAR: Action transfer_hbar blocked by policy: Max Recipients Policy',
+};
+
+const successEnvelope = {
+  raw: { status: 'SUCCESS', transactionId: '0.0.1@1.2' },
+  humanMessage: 'Done',
+};
+
+// Build a mock toolkit list with a parser for 'transfer_hbar'
+function buildTools(): any[] {
+  return [
+    {
+      name: 'transfer_hbar',
+      responseParsingFunction: (content: string) => JSON.parse(content),
+    },
+    {
+      name: 'get_balance',
+      responseParsingFunction: (content: string) => JSON.parse(content),
+    },
+  ];
+}
+
+describe('ResponseParserService – parsePolicyBlocks / hasPolicyBlocks (LangChain)', () => {
+  it('parsePolicyBlocks returns only policy-block entries', () => {
+    const service = new ResponseParserService(buildTools());
+    const response = {
+      messages: [
+        makeToolMessage('transfer_hbar', JSON.stringify(policyBlockEnvelope)),
+        makeToolMessage('get_balance', JSON.stringify(successEnvelope)),
+      ],
+    };
+
+    const blocks = service.parsePolicyBlocks(response);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].kind).toBe('policy_block');
+    expect(blocks[0].policyName).toBe('Max Recipients Policy');
+    expect(blocks[0].details).toEqual({ recipientCount: 3, maxRecipients: 1 });
+  });
+
+  it('parsePolicyBlocks returns empty array when no policy blocks', () => {
+    const service = new ResponseParserService(buildTools());
+    const response = {
+      messages: [makeToolMessage('get_balance', JSON.stringify(successEnvelope))],
+    };
+    expect(service.parsePolicyBlocks(response)).toHaveLength(0);
+  });
+
+  it('hasPolicyBlocks returns true when a policy block is present', () => {
+    const service = new ResponseParserService(buildTools());
+    const response = {
+      messages: [
+        makeToolMessage('transfer_hbar', JSON.stringify(policyBlockEnvelope)),
+      ],
+    };
+    expect(service.hasPolicyBlocks(response)).toBe(true);
+  });
+
+  it('hasPolicyBlocks returns false when no policy blocks', () => {
+    const service = new ResponseParserService(buildTools());
+    const response = {
+      messages: [makeToolMessage('get_balance', JSON.stringify(successEnvelope))],
+    };
+    expect(service.hasPolicyBlocks(response)).toBe(false);
+  });
+
+  it('parsePolicyBlocks deduplicates: same message id is not counted twice', () => {
+    const service = new ResponseParserService(buildTools());
+    const msg = makeToolMessage('transfer_hbar', JSON.stringify(policyBlockEnvelope));
+    // Same object twice (same `id`) — should be processed only once
+    const response = { messages: [msg, msg] };
+    const blocks = service.parsePolicyBlocks(response);
+    expect(blocks).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
- Introduced `PolicyResultParser` for structured policy block extraction.
- Enhanced `MaxRecipientsPolicy` to throw `PolicyBlockedError` with details.
- Added `MaintenanceModePolicy` example for demonstration.
- Updated tests to validate structured policy block data parsing.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #936

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
