### PR TITLE
docs: endorse hak-pyth-plugin@0.3.0 and flag the Pyth Core API-key deadline

### DIFF
--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -60,9 +60,16 @@ See this list of available third party plugins for the Hedera Agent Kit in the [
 
   Github repository: https://github.com/jmgomezl/hak-pyth-plugin
 
-  Version: hak-pyth-plugin@0.2.0
+  Version: hak-pyth-plugin@0.3.0
 
   Status: Validated by HAK team, v4-compatible release
+
+  > **Upgrade required before 2026-08-18.** Pyth Core now requires an API key
+  > ([OP-PIP-100](https://forum.pyth.network/t/passed-op-pip-100-pyth-core-to-pyth-pro-migration/2420)).
+  > From that date the Hermes endpoint rejects anonymous price requests, so versions
+  > below 0.3.0 stop returning prices. Upgrade to 0.3.0 and set `PYTH_API_KEY`
+  > ([get a key](https://docs.pyth.network/price-feeds/pro/acquire-api-key)); the plugin
+  > then targets the upgraded endpoint automatically.
 
 
 - [CoinCap Plugin](https://www.npmjs.com/package/coincap-hedera-plugin) provides access to the [**CoinCap API service**](https://www.coincap.io) to access cryptocurrency market data. It exposes the action (`get HBAR price in USD`) to get the current price of HBAR in USD currency, by using it you can ask your agent to get your current HBAR balance expressed in USD.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -81,7 +81,11 @@ The Hedera Agent Kit is extensible with third party plugins by other projects. S
 - [Pyth Plugin](https://www.npmjs.com/package/hak-pyth-plugin) provides access to the [**Pyth Network**](https://www.pyth.network/) price feeds via the Hermes API, exposing tools to list feeds and fetch latest prices:
 
   Github repository: [https://github.com/jmgomezl/hak-pyth-plugin](https://github.com/jmgomezl/hak-pyth-plugin).
-  Tested/endorsed version of plugin: hak-pyth-plugin@0.1.1
+  Tested/endorsed version of plugin: hak-pyth-plugin@0.3.0
+
+  > **Upgrade required before 2026-08-18.** Pyth Core now requires an API key, so versions
+  > below 0.3.0 stop returning prices on that date. Upgrade and set `PYTH_API_KEY` — see
+  > [docs/PLUGINS.md](../../docs/PLUGINS.md) for details.
 
 - [CoinCap Plugin](https://www.npmjs.com/package/coincap-hedera-plugin) provides access to the [**CoinCap API service**](https://www.coincap.io) to access cryptocurrency market data. It exposes the action (`get HBAR price in USD`) to get the current price of HBAR in USD currency, by using it you can ask your agent to get your current HBAR balance expressed in USD.
 


### PR DESCRIPTION
## What

Updates the endorsed version of `hak-pyth-plugin` to **0.3.0** in both places it is listed, and adds a time-sensitive upgrade note.

## Why

**1. The two lists were stale and disagreed with each other.**

| File | Was | Now |
|---|---|---|
| `docs/PLUGINS.md` | `0.2.0` | `0.3.0` |
| `packages/core/README.md` | `0.1.1` | `0.3.0` |

**2. There is a hard deadline attached to this one.**

Pyth Core requires an API key from **2026-08-18** under [OP-PIP-100](https://forum.pyth.network/t/passed-op-pip-100-pyth-core-to-pyth-pro-migration/2420). From that date the Hermes endpoint rejects anonymous price-update requests, so **every published version below 0.3.0 stops returning prices.** This is not a deprecation warning — the tools start failing.

I verified the enforcement is already live on the upgraded endpoint:

| Endpoint | `/v2/price_feeds` | `/v2/updates/price/latest` |
|---|---|---|
| `hermes.pyth.network` (current) | 200 | 200 |
| `pyth.dourolabs.app/hermes` (upgraded) | 200 | **401** |

0.3.0 adds API-key support and selects the endpoint accordingly: without a key it stays on the current Hermes host (works until 2026-08-18), and setting `PYTH_API_KEY` switches it to the upgraded authenticated endpoint. Upgrading is non-breaking — existing users keep working, and setting the env var is the whole migration.

Plugin-side change: [jmgomezl/hak-pyth-plugin#5](https://github.com/jmgomezl/hak-pyth-plugin/pull/5).

## Scope

Docs only — two version strings and two upgrade notes. No code changes.

Note: both files already fail `prettier --check` on `main` today, before this change. I left the existing formatting untouched so the diff stays reviewable rather than reformatting whole files in a docs PR.